### PR TITLE
Fix order of values popped from the operand stack

### DIFF
--- a/src/Kernel/Mnemonics/_dadd.php
+++ b/src/Kernel/Mnemonics/_dadd.php
@@ -11,8 +11,8 @@ final class _dadd implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::add($value1, $value2));
     }

--- a/src/Kernel/Mnemonics/_dmul.php
+++ b/src/Kernel/Mnemonics/_dmul.php
@@ -11,8 +11,8 @@ final class _dmul implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::multiply($value1, $value2, 8));
     }

--- a/src/Kernel/Mnemonics/_dsub.php
+++ b/src/Kernel/Mnemonics/_dsub.php
@@ -11,8 +11,8 @@ final class _dsub implements OperationInterface
 
     public function execute(): void
     {
-        $leftValue = $this->getStack();
         $rightValue = $this->getStack();
+        $leftValue = $this->getStack();
 
         $this->pushStack(BinaryTool::sub($leftValue, $rightValue, 8));
     }

--- a/src/Kernel/Mnemonics/_iadd.php
+++ b/src/Kernel/Mnemonics/_iadd.php
@@ -11,8 +11,8 @@ final class _iadd implements OperationInterface
 
     public function execute(): void
     {
-        $leftValue = $this->getStack();
         $rightValue = $this->getStack();
+        $leftValue = $this->getStack();
 
         $this->pushStack(BinaryTool::add($leftValue, $rightValue));
     }

--- a/src/Kernel/Mnemonics/_iand.php
+++ b/src/Kernel/Mnemonics/_iand.php
@@ -11,8 +11,8 @@ final class _iand implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::andBits($value1, $value2, 4));
     }

--- a/src/Kernel/Mnemonics/_if_acmpeq.php
+++ b/src/Kernel/Mnemonics/_if_acmpeq.php
@@ -13,8 +13,8 @@ final class _if_acmpeq implements OperationInterface
     {
         $offset = $this->readShort();
 
-        $leftOperand = $this->getStack();
         $rightOperand = $this->getStack();
+        $leftOperand = $this->getStack();
 
         if ($leftOperand === $rightOperand) {
             $this->setOffset($this->getProgramCounter() + $offset);

--- a/src/Kernel/Mnemonics/_if_acmpne.php
+++ b/src/Kernel/Mnemonics/_if_acmpne.php
@@ -13,8 +13,8 @@ final class _if_acmpne implements OperationInterface
     {
         $offset = $this->readShort();
 
-        $leftOperand = $this->getStack();
         $rightOperand = $this->getStack();
+        $leftOperand = $this->getStack();
 
         if ($leftOperand !== $rightOperand) {
             $this->setOffset($this->getProgramCounter() + $offset);

--- a/src/Kernel/Mnemonics/_if_icmpge.php
+++ b/src/Kernel/Mnemonics/_if_icmpge.php
@@ -13,10 +13,10 @@ final class _if_icmpge implements OperationInterface
     {
         $offset = $this->readShort();
 
-        $leftOperand = $this->getStack();
         $rightOperand = $this->getStack();
+        $leftOperand = $this->getStack();
 
-        if ($leftOperand <= $rightOperand) {
+        if ($leftOperand >= $rightOperand) {
             $this->setOffset($this->getProgramCounter() + $offset);
         }
     }

--- a/src/Kernel/Mnemonics/_if_icmpgt.php
+++ b/src/Kernel/Mnemonics/_if_icmpgt.php
@@ -13,10 +13,10 @@ final class _if_icmpgt implements OperationInterface
     {
         $offset = $this->readShort();
 
-        $leftOperand = $this->getStack();
         $rightOperand = $this->getStack();
+        $leftOperand = $this->getStack();
 
-        if ($leftOperand < $rightOperand) {
+        if ($leftOperand > $rightOperand) {
             $this->setOffset($this->getProgramCounter() + $offset);
         }
     }

--- a/src/Kernel/Mnemonics/_if_icmplt.php
+++ b/src/Kernel/Mnemonics/_if_icmplt.php
@@ -13,10 +13,10 @@ final class _if_icmplt implements OperationInterface
     {
         $offset = $this->readShort();
 
-        $leftOperand = $this->getStack();
         $rightOperand = $this->getStack();
+        $leftOperand = $this->getStack();
 
-        if ($rightOperand < $leftOperand) {
+        if ($leftOperand < $rightOperand) {
             $this->setOffset($this->getProgramCounter() + $offset);
         }
     }

--- a/src/Kernel/Mnemonics/_if_icmpne.php
+++ b/src/Kernel/Mnemonics/_if_icmpne.php
@@ -13,8 +13,8 @@ final class _if_icmpne implements OperationInterface
     {
         $offset = $this->readShort();
 
-        $leftOperand = $this->getStack();
         $rightOperand = $this->getStack();
+        $leftOperand = $this->getStack();
 
         if ($leftOperand != $rightOperand) {
             $this->setOffset($this->getProgramCounter() + $offset);

--- a/src/Kernel/Mnemonics/_imul.php
+++ b/src/Kernel/Mnemonics/_imul.php
@@ -11,8 +11,8 @@ final class _imul implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::multiply($value1, $value2, 4));
     }

--- a/src/Kernel/Mnemonics/_ior.php
+++ b/src/Kernel/Mnemonics/_ior.php
@@ -11,8 +11,8 @@ final class _ior implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::orBits($value1, $value2, 4));
     }

--- a/src/Kernel/Mnemonics/_ishl.php
+++ b/src/Kernel/Mnemonics/_ishl.php
@@ -11,8 +11,8 @@ final class _ishl implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::shiftLeft($value1, $value2));
     }

--- a/src/Kernel/Mnemonics/_ishr.php
+++ b/src/Kernel/Mnemonics/_ishr.php
@@ -11,8 +11,8 @@ final class _ishr implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::shiftRight($value1, $value2, 4));
     }

--- a/src/Kernel/Mnemonics/_isub.php
+++ b/src/Kernel/Mnemonics/_isub.php
@@ -11,8 +11,8 @@ final class _isub implements OperationInterface
 
     public function execute(): void
     {
-        $leftValue = $this->getStack();
         $rightValue = $this->getStack();
+        $leftValue = $this->getStack();
 
         $this->pushStack(BinaryTool::sub($leftValue, $rightValue, 4));
     }

--- a/src/Kernel/Mnemonics/_iushr.php
+++ b/src/Kernel/Mnemonics/_iushr.php
@@ -11,8 +11,8 @@ final class _iushr implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::unsignedShiftRight($value1, $value2, 4));
     }

--- a/src/Kernel/Mnemonics/_ixor.php
+++ b/src/Kernel/Mnemonics/_ixor.php
@@ -11,8 +11,8 @@ final class _ixor implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::xorBits($value1, $value2, 4));
     }

--- a/src/Kernel/Mnemonics/_ladd.php
+++ b/src/Kernel/Mnemonics/_ladd.php
@@ -11,8 +11,8 @@ final class _ladd implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::add($value1, $value2));
     }

--- a/src/Kernel/Mnemonics/_land.php
+++ b/src/Kernel/Mnemonics/_land.php
@@ -11,8 +11,8 @@ final class _land implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::andBits($value1, $value2, 8));
     }

--- a/src/Kernel/Mnemonics/_lmul.php
+++ b/src/Kernel/Mnemonics/_lmul.php
@@ -11,8 +11,8 @@ final class _lmul implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::multiply($value1, $value2, 8));
     }

--- a/src/Kernel/Mnemonics/_lor.php
+++ b/src/Kernel/Mnemonics/_lor.php
@@ -11,8 +11,8 @@ final class _lor implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::orBits($value1, $value2, 8));
     }

--- a/src/Kernel/Mnemonics/_lshl.php
+++ b/src/Kernel/Mnemonics/_lshl.php
@@ -11,8 +11,8 @@ final class _lshl implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::shiftLeft($value1, $value2));
     }

--- a/src/Kernel/Mnemonics/_lshr.php
+++ b/src/Kernel/Mnemonics/_lshr.php
@@ -11,8 +11,8 @@ final class _lshr implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::shiftRight($value1, $value2, 8));
     }

--- a/src/Kernel/Mnemonics/_lsub.php
+++ b/src/Kernel/Mnemonics/_lsub.php
@@ -11,8 +11,8 @@ final class _lsub implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::sub($value1, $value2, 8));
     }

--- a/src/Kernel/Mnemonics/_lushr.php
+++ b/src/Kernel/Mnemonics/_lushr.php
@@ -11,8 +11,8 @@ final class _lushr implements OperationInterface
 
     public function execute(): void
     {
-        $value1 = $this->getStack();
         $value2 = $this->getStack();
+        $value1 = $this->getStack();
 
         $this->pushStack(BinaryTool::unsignedShiftRight($value1, $value2, 8));
     }

--- a/src/Utilities/BinaryTool.php
+++ b/src/Utilities/BinaryTool.php
@@ -135,9 +135,9 @@ class BinaryTool
     {
         $value1 = (int) $value1;
         $value2 = (int) $value2;
-        $bits = sprintf('%0' . ($bytes * 8) . 's', base_convert($value2, 10, 2));
+        $bits = sprintf('%0' . ($bytes * 8) . 's', base_convert($value1, 10, 2));
 
-        $bits = sprintf('%0' . ($bytes * 8) . 's', substr($bits, 0, strlen($bits) - $value1));
+        $bits = sprintf('%0' . ($bytes * 8) . 's', substr($bits, 0, strlen($bits) - $value2));
 
         if ($bits === '') {
             $bits = '0';

--- a/tests/BinaryOperatorTest.php
+++ b/tests/BinaryOperatorTest.php
@@ -1,0 +1,85 @@
+<?php
+namespace PHPJava\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class BinaryOperatorTest extends Base
+{
+    protected $fixtures = [
+        'BinaryOperatorTest',
+    ];
+
+    private function call($method, $value1, $value2)
+    {
+        $calculatedValue = $this->initiatedJavaClasses['BinaryOperatorTest']
+            ->getInvoker()
+            ->getStatic()
+            ->getMethods()
+            ->call($method, $value1, $value2);
+
+        return $calculatedValue->getValue();
+    }
+
+    public function testIntAdd()
+    {
+        $actual = $this->call('intAdd', 5, 3);
+        $this->assertEquals(8, $actual);
+    }
+
+    public function testIntSub()
+    {
+        $actual = $this->call('intSub', 5, 3);
+        $this->assertEquals(2, $actual);
+    }
+
+    public function testIntMul()
+    {
+        $actual = $this->call('intMul', 5, 3);
+        $this->assertEquals(15, $actual);
+    }
+
+    public function testIntShl()
+    {
+        $actual = $this->call('intShl', 3, 2);
+        $this->assertEquals(12, $actual);
+    }
+
+    public function testIntShr()
+    {
+        $actual = $this->call('intShr', 12, 2);
+        $this->assertEquals(3, $actual);
+    }
+
+    public function testIntUshr()
+    {
+        $actual = $this->call('intUshr', 12, 2);
+        $this->assertEquals(3, $actual);
+    }
+
+    public function testIntAnd()
+    {
+        $value1 = (int) base_convert('0011', 2, 10);
+        $value2 = (int) base_convert('0101', 2, 10);
+        $expect = (int) base_convert('0001', 2, 10);
+        $actual = $this->call('intAnd', $value1, $value2);
+        $this->assertEquals($expect, $actual);
+    }
+
+    public function testIntOr()
+    {
+        $value1 = (int) base_convert('0011', 2, 10);
+        $value2 = (int) base_convert('0101', 2, 10);
+        $expect = (int) base_convert('0111', 2, 10);
+        $actual = $this->call('intOr', $value1, $value2);
+        $this->assertEquals($expect, $actual);
+    }
+
+    public function testIntXor()
+    {
+        $value1 = (int) base_convert('0011', 2, 10);
+        $value2 = (int) base_convert('0101', 2, 10);
+        $expect = (int) base_convert('0110', 2, 10);
+        $actual = $this->call('intXor', $value1, $value2);
+        $this->assertEquals($expect, $actual);
+    }
+}

--- a/tests/BranchIfTest.php
+++ b/tests/BranchIfTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace PHPJava\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class BranchIfTest extends Base
+{
+    protected $fixtures = [
+        'BranchIfTest',
+    ];
+
+    private function call($method, $value1, $value2)
+    {
+        $calculatedValue = $this->initiatedJavaClasses['BranchIfTest']
+            ->getInvoker()
+            ->getStatic()
+            ->getMethods()
+            ->call($method, $value1, $value2);
+
+        return $calculatedValue->getValue();
+    }
+
+    public function testIfAcmpEq()
+    {
+        $actual = $this->call('ifAcmpEq', 'value1', 'value2');
+        $this->assertEquals(0, $actual);
+    }
+
+    public function testIfAcmpNe()
+    {
+        $actual = $this->call('ifAcmpNe', 'value1', 'value2');
+        $this->assertEquals(1, $actual);
+    }
+
+    // public function testIfIcmpEq()
+    // {
+    //     $actual = $this->call('ifIcmpEq', 5, 3);
+    //     $this->assertEquals(0, $actual);
+    // }
+
+    public function testIfIcmpNe()
+    {
+        $actual = $this->call('ifIcmpNe', 5, 3);
+        $this->assertEquals(1, $actual);
+    }
+
+    public function testIfIcmpLt()
+    {
+        $actual = $this->call('ifIcmpLt', 5, 3);
+        $this->assertEquals(0, $actual);
+    }
+
+    public function testIfIcmpGe()
+    {
+        $actual = $this->call('ifIcmpGe', 5, 3);
+        $this->assertEquals(1, $actual);
+    }
+
+    public function testIfIcmpGt()
+    {
+        $actual = $this->call('ifIcmpGt', 5, 3);
+        $this->assertEquals(1, $actual);
+    }
+
+    // public function testIfIcmpLe()
+    // {
+    //     $actual = $this->call('ifIcmpLe', 5, 3);
+    //     $this->assertEquals(0, $actual);
+    // }
+}

--- a/tests/fixtures/java/BinaryOperatorTest.java
+++ b/tests/fixtures/java/BinaryOperatorTest.java
@@ -1,0 +1,47 @@
+class BinaryOperatorTest
+{
+    public static int intAdd(int value1, int value2)
+    {
+	return value1 + value2;
+    }
+
+    public static int intSub(int value1, int value2)
+    {
+	return value1 - value2;
+    }
+
+    public static int intMul(int value1, int value2)
+    {
+	return value1 * value2;
+    }
+
+    public static int intShl(int value1, int value2)
+    {
+	return value1 << value2;
+    }
+
+    public static int intShr(int value1, int value2)
+    {
+	return value1 >> value2;
+    }
+
+    public static int intUshr(int value1, int value2)
+    {
+	return value1 >>> value2;
+    }
+
+    public static int intAnd(int value1, int value2)
+    {
+	return value1 & value2;
+    }
+
+    public static int intOr(int value1, int value2)
+    {
+	return value1 | value2;
+    }
+
+    public static int intXor(int value1, int value2)
+    {
+	return value1 ^ value2;
+    }
+}

--- a/tests/fixtures/java/BranchIfTest.java
+++ b/tests/fixtures/java/BranchIfTest.java
@@ -1,0 +1,42 @@
+class BranchIfTest
+{
+    public static int ifAcmpEq(String value1, String value2)
+    {
+	return value1 != value2 ? 0 : 1;
+    }
+
+    public static int ifAcmpNe(String value1, String value2)
+    {
+	return value1 == value2 ? 0 : 1;
+    }
+
+    public static int ifIcmpEq(int value1, int value2)
+    {
+	return value1 != value2 ? 0 : 1;
+    }
+
+    public static int ifIcmpNe(int value1, int value2)
+    {
+	return value1 == value2 ? 0 : 1;
+    }
+
+    public static int ifIcmpLt(int value1, int value2)
+    {
+	return value1 >= value2 ? 0 : 1;
+    }
+
+    public static int ifIcmpGe(int value1, int value2)
+    {
+	return value1 < value2 ? 0 : 1;
+    }
+
+    public static int ifIcmpGt(int value1, int value2)
+    {
+	return value1 <= value2 ? 0 : 1;
+    }
+
+    public static int ifIcmpLe(int value1, int value2)
+    {
+	return value1 > value2 ? 0 : 1;
+    }
+}


### PR DESCRIPTION
In binary operations such as iadd, isub, etc., the order of values popped from the operand stack is wrong. It should be right-to-left order. This PR will do:
- fix implementations of those instructions
- add test cases for integer arithmetics, logicals, and branches