### PR TITLE
Fix stack usage

### DIFF
--- a/src/Kernel/Mnemonics/_aaload.php
+++ b/src/Kernel/Mnemonics/_aaload.php
@@ -3,6 +3,7 @@ namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
 use PHPJava\Utilities\BinaryTool;
+use PHPJava\Utilities\Extractor;
 
 final class _aaload implements OperationInterface
 {
@@ -14,7 +15,7 @@ final class _aaload implements OperationInterface
      */
     public function execute(): void
     {
-        $index = $this->getStack();
+        $index = Extractor::realValue($this->getStack());
         $arrayref = $this->getStack();
 
         if (!isset($arrayref[$index])) {

--- a/src/Kernel/Mnemonics/_bipush.php
+++ b/src/Kernel/Mnemonics/_bipush.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _bipush implements OperationInterface
@@ -11,6 +12,6 @@ final class _bipush implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack($this->readByte());
+        $this->pushStack(new _Int($this->readByte()));
     }
 }

--- a/src/Kernel/Mnemonics/_iaload.php
+++ b/src/Kernel/Mnemonics/_iaload.php
@@ -3,6 +3,7 @@ namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
 use PHPJava\Utilities\BinaryTool;
+use PHPJava\Utilities\Extractor;
 
 final class _iaload implements OperationInterface
 {
@@ -11,7 +12,7 @@ final class _iaload implements OperationInterface
 
     public function execute(): void
     {
-        $index = $this->getStack();
+        $index = Extractor::realValue($this->getStack());
         $arrayref = $this->getStack();
         
         $this->pushStack($arrayref[$index]);

--- a/src/Kernel/Mnemonics/_iconst_0.php
+++ b/src/Kernel/Mnemonics/_iconst_0.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_0 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_0 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(0);
+        $this->pushStack(new _Int(0));
     }
 }

--- a/src/Kernel/Mnemonics/_iconst_1.php
+++ b/src/Kernel/Mnemonics/_iconst_1.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_1 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_1 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(1);
+        $this->pushStack(new _Int(1));
     }
 }

--- a/src/Kernel/Mnemonics/_iconst_2.php
+++ b/src/Kernel/Mnemonics/_iconst_2.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_2 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_2 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(2);
+        $this->pushStack(new _Int(2));
     }
 }

--- a/src/Kernel/Mnemonics/_iconst_3.php
+++ b/src/Kernel/Mnemonics/_iconst_3.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_3 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_3 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(3);
+        $this->pushStack(new _Int(3));
     }
 }

--- a/src/Kernel/Mnemonics/_iconst_4.php
+++ b/src/Kernel/Mnemonics/_iconst_4.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_4 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_4 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(4);
+        $this->pushStack(new _Int(4));
     }
 }

--- a/src/Kernel/Mnemonics/_iconst_5.php
+++ b/src/Kernel/Mnemonics/_iconst_5.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_5 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_5 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(5);
+        $this->pushStack(new _Int(5));
     }
 }

--- a/src/Kernel/Mnemonics/_iconst_m1.php
+++ b/src/Kernel/Mnemonics/_iconst_m1.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
 
 final class _iconst_m1 implements OperationInterface
@@ -11,6 +12,6 @@ final class _iconst_m1 implements OperationInterface
 
     public function execute(): void
     {
-        $this->pushStack(-1);
+        $this->pushStack(new _Int(-1));
     }
 }

--- a/src/Kernel/Mnemonics/_iinc.php
+++ b/src/Kernel/Mnemonics/_iinc.php
@@ -2,7 +2,9 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Exceptions\NotImplementedException;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Utilities\BinaryTool;
+use PHPJava\Utilities\Extractor;
 
 final class _iinc implements OperationInterface
 {
@@ -14,6 +16,8 @@ final class _iinc implements OperationInterface
         $index = $this->readUnsignedByte();
         $const = $this->readByte();
 
-        $this->setLocalStorage($index, $this->getLocalStorage($index) + $const);
+        $value = Extractor::realValue($this->getLocalStorage($index));
+
+        $this->setLocalStorage($index, new _Int($value + $const));
     }
 }

--- a/tests/AccessDynamicFieldTest.php
+++ b/tests/AccessDynamicFieldTest.php
@@ -12,7 +12,7 @@ class AccessDynamicFieldTest extends Base
     public function testGetPuttedField()
     {
         $constructed = $this->initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
-        $this->assertEquals(5, $constructed->getDynamic()->getFields()->get('number'));
+        $this->assertEquals(5, $constructed->getDynamic()->getFields()->get('number')->getValue());
         $this->assertEquals('Hello World', $constructed->getDynamic()->getFields()->get('string'));
     }
 
@@ -33,7 +33,7 @@ class AccessDynamicFieldTest extends Base
 
         // affected assertion
         $constructed = $this->initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
-        $this->assertEquals(5, $constructed->getDynamic()->getFields()->get('number'));
+        $this->assertEquals(5, $constructed->getDynamic()->getFields()->get('number')->getValue());
         $this->assertEquals('Hello World', $constructed->getDynamic()->getFields()->get('string'));
     }
 }

--- a/tests/AccessStaticFieldTest.php
+++ b/tests/AccessStaticFieldTest.php
@@ -11,7 +11,7 @@ class AccessStaticFieldTest extends Base
 
     public function testGetPuttedField()
     {
-        $this->assertEquals(5, $this->initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('number'));
+        $this->assertEquals(5, $this->initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('number')->getValue());
         $this->assertEquals('Hello World', $this->initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('string'));
     }
 

--- a/tests/IntConstTest.php
+++ b/tests/IntConstTest.php
@@ -1,0 +1,70 @@
+<?php
+namespace PHPJava\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class IntConstTest extends Base
+{
+    protected $fixtures = [
+        'IntConstTest',
+    ];
+
+    private function call($method)
+    {
+        $calculatedValue = $this->initiatedJavaClasses['IntConstTest']
+            ->getInvoker()
+            ->getStatic()
+            ->getMethods()
+            ->call($method);
+
+        return $calculatedValue->getValue();
+    }
+
+    public function testIntConst0()
+    {
+        $actual = $this->call('intConst0');
+        $this->assertEquals(0, $actual);
+    }
+
+    public function testIntConst1()
+    {
+        $actual = $this->call('intConst1');
+        $this->assertEquals(1, $actual);
+    }
+
+    public function testIntConst2()
+    {
+        $actual = $this->call('intConst2');
+        $this->assertEquals(2, $actual);
+    }
+
+    public function testIntConst3()
+    {
+        $actual = $this->call('intConst3');
+        $this->assertEquals(3, $actual);
+    }
+
+    public function testIntConst4()
+    {
+        $actual = $this->call('intConst4');
+        $this->assertEquals(4, $actual);
+    }
+
+    public function testIntConst5()
+    {
+        $actual = $this->call('intConst5');
+        $this->assertEquals(5, $actual);
+    }
+
+    public function testIntConstM1()
+    {
+        $actual = $this->call('intConstM1');
+        $this->assertEquals(-1, $actual);
+    }
+
+    public function testIntPush123()
+    {
+        $actual = $this->call('intPush123');
+        $this->assertEquals(123, $actual);
+    }
+}

--- a/tests/fixtures/java/IntConstTest.java
+++ b/tests/fixtures/java/IntConstTest.java
@@ -1,0 +1,42 @@
+class IntConstTest
+{
+    public static int intConst0()
+    {
+	return 0;
+    }
+
+    public static int intConst1()
+    {
+	return 1;
+    }
+
+    public static int intConst2()
+    {
+	return 2;
+    }
+
+    public static int intConst3()
+    {
+	return 3;
+    }
+
+    public static int intConst4()
+    {
+	return 4;
+    }
+
+    public static int intConst5()
+    {
+	return 5;
+    }
+
+    public static int intConstM1()
+    {
+	return -1;
+    }
+
+    public static int intPush123()
+    {
+	return 123;
+    }
+}


### PR DESCRIPTION
Fix iconst and bipush instructions to push _Int values onto the operand stack, rather than primitive int values.
This change broke some test cases. Those are fixed in the second commit in this PR.
(Though all test cases are passed at the moment, there may be other problems to be fixed.)