### PR TITLE
Add a php_cs config file to apply a declared policy automatically

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder)
+;


### PR DESCRIPTION
I added a `.php_cs.dist` file so that contributors don't have to worry about which rules to apply.

This file let us invoke the php-cs-fixer without any options.

```
./vendor/bin/php-cs-fixer fix
```

The configuration I made is  just a basement, so if you would like to change anything,   please feel free to make comments or modify it. :pray:
