### PR TITLE
Handle the previous exception in UnableToCatchException

### DIFF
--- a/src/Kernel/Mnemonics/_invokestatic.php
+++ b/src/Kernel/Mnemonics/_invokestatic.php
@@ -89,10 +89,12 @@ final class _invokestatic implements OperationInterface
             }
 
             throw new UnableToCatchException(
-                $expectedClass . ': ' . $e->getMessage()
+                $expectedClass . ': ' . $e->getMessage(),
+                0,
+                $e
             );
         }
-        
+
         if ($signature[0]['type'] !== 'void') {
             $this->pushToOperandStack($return);
         }

--- a/src/Kernel/Mnemonics/_invokevirtual.php
+++ b/src/Kernel/Mnemonics/_invokevirtual.php
@@ -82,7 +82,9 @@ final class _invokevirtual implements OperationInterface
             }
 
             throw new UnableToCatchException(
-                $expectedClass . ': ' . $e->getMessage()
+                $expectedClass . ': ' . $e->getMessage(),
+                0,
+                $e
             );
         }
 

--- a/tests/TryCatchTest.php
+++ b/tests/TryCatchTest.php
@@ -55,6 +55,9 @@ class TryCatchTest extends Base
 
     public function testImitationThrownExceptionHasPreviousException()
     {
+        $this->expectException(IndexOutOfBoundsException::class);
+        $this->expectExceptionMessage('String index out of range: -1');
+
         try {
             $result = $this->initiatedJavaClasses['TryCatchTest']
                 ->getInvoker()
@@ -62,14 +65,8 @@ class TryCatchTest extends Base
                 ->getMethods()
                 ->call('testImitationThrownExceptionHasPreviousException');
         } catch (UnableToCatchException $e) {
-            $this->assertInstanceOf(
-                IndexOutOfBoundsException::class,
-                $e->getPrevious()
-            );
-            $this->assertEquals(
-                'String index out of range: -1',
-                $e->getPrevious()->getMessage()
-            );
+            // Unwrap the original exception
+            throw $e->getPrevious();
         }
     }
 }

--- a/tests/TryCatchTest.php
+++ b/tests/TryCatchTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace PHPJava\Tests;
 
+use PHPJava\Exceptions\UnableToCatchException;
+use PHPJava\Packages\java\lang\IndexOutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 
 class TryCatchTest extends Base
@@ -37,7 +39,7 @@ class TryCatchTest extends Base
         );
     }
 
-    public function testImitationThroExceptionw()
+    public function testImitationThrowException()
     {
         $result = $this->initiatedJavaClasses['TryCatchTest']
             ->getInvoker()
@@ -49,5 +51,25 @@ class TryCatchTest extends Base
             '-1',
             $result
         );
+    }
+
+    public function testImitationThrownExceptionHasPreviousException()
+    {
+        try {
+            $result = $this->initiatedJavaClasses['TryCatchTest']
+                ->getInvoker()
+                ->getStatic()
+                ->getMethods()
+                ->call('testImitationThrownExceptionHasPreviousException');
+        } catch (UnableToCatchException $e) {
+            $this->assertInstanceOf(
+                IndexOutOfBoundsException::class,
+                $e->getPrevious()
+            );
+            $this->assertEquals(
+                'String index out of range: -1',
+                $e->getPrevious()->getMessage()
+            );
+        }
     }
 }

--- a/tests/fixtures/java/TryCatchTest.java
+++ b/tests/fixtures/java/TryCatchTest.java
@@ -33,4 +33,9 @@ class TryCatchTest
 
         return 1;
     }
+
+    public static void testImitationThrownExceptionHasPreviousException()
+    {
+        "".charAt(-1);
+    }
 }


### PR DESCRIPTION
Let's make use of `Exception::getPrevious()` when `UnableToCatchException` is thrown!