### PR TITLE
[WIP] Fix getfield (need review)

### DIFF
--- a/src/Kernel/Mnemonics/_getfield.php
+++ b/src/Kernel/Mnemonics/_getfield.php
@@ -12,17 +12,19 @@ final class _getfield implements OperationInterface
     public function execute(): void
     {
         $cpInfo = $this->getConstantPool();
-
         $cp = $cpInfo[$this->readUnsignedShort()];
+        $class = $cpInfo[$cp->getNameAndTypeIndex()];
 
-        $get = $this->popFromOperandStack();
+        $name = $cpInfo[$class->getNameIndex()]->getString();
+        $objectref = $this->popFromOperandStack();
 
-        $return = $get->getInstance($cpInfo[$cpInfo[$cp->getNameAndTypeIndex()]->getNameIndex()]->getString());
+        $return = $objectref->getInvoker()->getDynamic()->getFields()->get($name);
 
         if ($return !== null) {
             $this->pushToOperandStack($return);
             return;
         }
-        throw new Exception('Cannot get to undefined Field ' . $cpInfo[$cpInfo[$cp->getNameAndTypeIndex()]->getNameIndex()]->getString() . '');
+
+        throw new Exception('Cannot get to undefined Field ' . $name);
     }
 }

--- a/src/Kernel/Mnemonics/_invokespecial.php
+++ b/src/Kernel/Mnemonics/_invokespecial.php
@@ -38,14 +38,6 @@ final class _invokespecial implements OperationInterface
 
         $methodName = $cpInfo[$nameAndTypeIndex->getNameIndex()]->getString();
 
-        if ($this->javaClassInvoker->isInvoked($methodName, $signature)) {
-            return;
-        }
-
-        $this->javaClassInvoker
-            ->addToSpecialInvokedList($methodName, $signature);
-
-
         try {
             if ($invokerClass instanceof JavaClass) {
                 if ($invokerClass->getInvoker()->isInvoked($methodName, $signature)) {

--- a/tests/GetFieldTest.php
+++ b/tests/GetFieldTest.php
@@ -1,0 +1,23 @@
+<?php
+namespace PHPJava\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class GetFieldTest extends Base
+{
+    protected $fixtures = [
+        'GetFieldTest',
+    ];
+
+    public function testGetField()
+    {
+        $actual = $this->initiatedJavaClasses['GetFieldTest']
+            ->getInvoker()
+            ->getStatic()
+            ->getMethods()
+            ->call('getField')
+            ->getValue();
+
+        $this->assertEquals(1, $actual);
+    }
+}

--- a/tests/fixtures/java/GetFieldTest.java
+++ b/tests/fixtures/java/GetFieldTest.java
@@ -1,0 +1,9 @@
+class GetFieldTest
+{
+    public int value = 1;
+
+    public static int getField() {
+	GetFieldTest instance = new GetFieldTest();
+	return instance.value;
+    }
+}


### PR DESCRIPTION
Hi, all.
I'm trying to fix the implementation of getfield but I need your review. I don't understand the purpose of "return if isInvoked" guard, where we can find in _invokespecial.php.

**Description**

_getfield.php doesn't work currently as `getInstance` method is not defined. I added a text case and fixed the implementation in _getfield.php, in the 1st commit (f668d08). I think this is a right fix.

This fix is incomplete unfortunately. Following error is reported since _invokespecial doesn't initialize instance fields (I think this is other bug in _invokespecial.php).
```
1) PHPJava\Tests\GetFieldTest::testGetField
PHPJava\Packages\java\lang\NoSuchFieldException: Get to undefined Field value
```

The 2nd commit (5f191cc) fixes this, but it breaks InnerClassTest on the other hand. I have not found the right fix applicable for both.
```
1) PHPJava\Tests\InnerClassTest::testCallMainHavingStringArguments
PHPJava\Exceptions\UnableToCatchException: PHPJava.Exceptions.UnableToCatchException: PHPUnit.Framework.Error.Warning: class_parents(): Class \PHPJava\Packages\InnerClassTest$InnerClassTestInnerClass does not exist and could not be loaded
```