### PR TITLE
Add FreezableInterface to manage the _Utf8

### DIFF
--- a/src/Core/JVM/ConstantPool.php
+++ b/src/Core/JVM/ConstantPool.php
@@ -19,6 +19,7 @@ use PHPJava\Kernel\Structures\_MethodType;
 use PHPJava\Kernel\Structures\_NameAndType;
 use PHPJava\Kernel\Structures\_String;
 use PHPJava\Kernel\Structures\_Utf8;
+use PHPJava\Kernel\Structures\FreezableInterface;
 use PHPJava\Kernel\Structures\StructureInterface;
 
 class ConstantPool implements \ArrayAccess, \Countable, \IteratorAggregate
@@ -110,6 +111,9 @@ class ConstantPool implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function offsetGet($offset)
     {
+        if ($this->entries[$offset] instanceof FreezableInterface) {
+            $this->entries[$offset]->freeze();
+        }
         return $this->entries[$offset];
     }
 

--- a/src/Kernel/Structures/FreezableInterface.php
+++ b/src/Kernel/Structures/FreezableInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PHPJava\Kernel\Structures;
+
+interface FreezableInterface
+{
+    public function freeze(): void;
+}

--- a/src/Kernel/Structures/_Utf8.php
+++ b/src/Kernel/Structures/_Utf8.php
@@ -5,7 +5,7 @@ use PHPJava\Exceptions\NotImplementedException;
 use PHPJava\Exceptions\ReadOnlyException;
 use PHPJava\Utilities\BinaryTool;
 
-class _Utf8 implements StructureInterface
+class _Utf8 implements StructureInterface, FreezableInterface
 {
     use \PHPJava\Kernel\Core\BinaryReader;
     use \PHPJava\Kernel\Core\ConstantPool;
@@ -13,7 +13,8 @@ class _Utf8 implements StructureInterface
 
     private $length = 0;
     private $string = '';
-    private $isWritable = false;
+    private $isWritable = null;
+    private $isFrozen = false;
 
     /**
      * @var \PHPJava\Packages\java\lang\_String $stringObject
@@ -29,39 +30,46 @@ class _Utf8 implements StructureInterface
         $this->stringObject = new \PHPJava\Packages\java\lang\_String($this);
     }
 
-    public function getLength()
+    public function getLength(): int
     {
         return $this->length;
     }
 
-    /**
-     * @param bool $enable
-     * @return _Utf8
-     */
     public function enableWrite(bool $enable): self
     {
-        $this->isWritable = $enable;
+        if (!$this->isFrozen) {
+            $this->isWritable = $enable;
+        }
         return $this;
     }
 
-    public function getString()
+    public function freeze(): void
+    {
+        $this->isFrozen = true;
+        $this->enableWrite(false);
+    }
+
+    public function getString(): string
     {
         return $this->string;
-    }
-
-    public function __toString(): string
-    {
-        return $this->getString();
-    }
-
-    public function setStringObject(\PHPJava\Packages\java\lang\_String $stringObject): self
-    {
-        $this->stringObject = $stringObject;
-        return $this;
     }
 
     public function getStringObject(): \PHPJava\Packages\java\lang\_String
     {
         return $this->stringObject;
+    }
+
+    public function setStringObject(\PHPJava\Packages\java\lang\_String $stringObject): self
+    {
+        if ($this->isWritable) {
+            $this->stringObject = $stringObject;
+            $this->freeze();
+        }
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getString();
     }
 }

--- a/src/Packages/java/lang/_String.php
+++ b/src/Packages/java/lang/_String.php
@@ -363,8 +363,7 @@ class _String extends _Object implements CharSequence
             if ((string) $value === (string) $this->object) {
                 $this->object = $value
                     ->enableWrite(true)
-                    ->setStringObject($this)
-                    ->enableWrite(false);
+                    ->setStringObject($this);
                 break;
             }
         }


### PR DESCRIPTION
Related: #135 

Because the string literal becomes non-writable when it appears (https://github.com/php-java/php-java/pull/135#issuecomment-490729688), this PR adds `FreezableInterface` so it turns the `_Utf8` instance to non-writable status which prevents `String#intern()` from writing to it.