### PR TITLE
Resolve #147: Add commit hook for pre-commit code fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.lock
 tests/caches/
 !tests/caches/.gitkeep
 tools
+cghooks.lock

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.4",
-        "friendsofphp/php-cs-fixer": "^2.14"
+        "friendsofphp/php-cs-fixer": "^2.14",
+        "brainmaestro/composer-git-hooks": "^2.6"
     },
     "scripts": {
         "test": "phpunit tests --stop-on-failure",
@@ -44,6 +45,13 @@
             "@test",
             "@cs",
             "@fix"
-        ]
+        ],
+        "post-install-cmd": "cghooks add --ignore-lock",
+        "post-update-cmd": "cghooks update"
+    },
+    "extra": {
+        "hooks": {
+            "pre-commit": "git diff-index --cached --name-only HEAD | xargs -n1 vendor/bin/php-cs-fixer fix"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,10 @@
     },
     "extra": {
         "hooks": {
-            "pre-commit": "git diff-index --cached --name-only HEAD | xargs -n1 vendor/bin/php-cs-fixer fix"
+            "pre-commit": [
+                "git diff-index --cached --name-only HEAD | vendor/bin/php-cs-fixer fix",
+                "git update-index --again"
+            ]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
             "@cs",
             "@fix"
         ],
-        "post-install-cmd": "[[ \"$COMPOSER_DEV_MODE\" = 1 ]] && cghooks add --ignore-lock",
-        "post-update-cmd": "[[ \"$COMPOSER_DEV_MODE\" = 1 ]] && cghooks update"
+        "post-install-cmd": "[ \"$COMPOSER_DEV_MODE\" = 1 ] && cghooks add --ignore-lock",
+        "post-update-cmd": "[ \"$COMPOSER_DEV_MODE\" = 1 ] && cghooks update"
     },
     "extra": {
         "hooks": {

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,8 @@
             "@cs",
             "@fix"
         ],
-        "post-install-cmd": "cghooks add --ignore-lock",
-        "post-update-cmd": "cghooks update"
+        "post-install-cmd": "[[ \"$COMPOSER_DEV_MODE\" = 1 ]] && cghooks add --ignore-lock",
+        "post-update-cmd": "[[ \"$COMPOSER_DEV_MODE\" = 1 ]] && cghooks update"
     },
     "extra": {
         "hooks": {


### PR DESCRIPTION
This PR adds a commit hook for `pre-commit` that executes `php-cs-fixer` for the files in the git staging area.