### PR TITLE
Add boundary value tests

### DIFF
--- a/src/Kernel/Filters/Normalizer.php
+++ b/src/Kernel/Filters/Normalizer.php
@@ -71,16 +71,17 @@ class Normalizer
              */
             $cp = $value->getConstantPool();
             $descriptor = Formatter::parseSignature($cp[$value->getDescriptorIndex()]->getString());
-            [$type, $class] = TypeResolver::getType($descriptor[0]);
+            [$type, $class, $deepArray] = TypeResolver::getType($descriptor[0]);
+
             switch ($type) {
                 case TypeResolver::IS_PRIMITIVE:
-                    /**
-                     * @var Type $class
-                     */
                     $newFields[$name] = $class::get();
                     break;
                 case TypeResolver::IS_CLASS:
                     $newFields[$name] = JavaClass::load('java.lang.Object');
+                    break;
+                case TypeResolver::IS_ARRAY:
+                    $newFields[$name] = null;
                     break;
                 default:
                     throw new NormalizerException('Failed to normalize fields.');

--- a/src/Kernel/Mnemonics/_aastore.php
+++ b/src/Kernel/Mnemonics/_aastore.php
@@ -16,7 +16,6 @@ final class _aastore implements OperationInterface
         $value = $this->popFromOperandStack();
         $index = Normalizer::getPrimitiveValue($this->popFromOperandStack());
         $arrayref = $this->popFromOperandStack();
-
         $arrayref[$index] = $value;
     }
 }

--- a/src/Kernel/Mnemonics/_bastore.php
+++ b/src/Kernel/Mnemonics/_bastore.php
@@ -21,9 +21,5 @@ final class _bastore implements OperationInterface
 
         // The value is a ref.
         $arrayref[$index] = $value;
-
-        $this->pushToOperandStack(
-            $arrayref
-        );
     }
 }

--- a/src/Kernel/Mnemonics/_castore.php
+++ b/src/Kernel/Mnemonics/_castore.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Kernel\Filters\Normalizer;
+use PHPJava\Kernel\Types\_Char;
 use PHPJava\Kernel\Types\Type;
 
 final class _castore implements OperationInterface
@@ -20,10 +21,6 @@ final class _castore implements OperationInterface
         $arrayref = $this->popFromOperandStack();
 
         // The value is a ref.
-        $arrayref[$index] = chr($value);
-
-        $this->pushToOperandStack(
-            $arrayref
-        );
+        $arrayref[$index] = _Char::get($value);
     }
 }

--- a/src/Kernel/Mnemonics/_dastore.php
+++ b/src/Kernel/Mnemonics/_dastore.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Kernel\Filters\Normalizer;
+use PHPJava\Kernel\Types\_Double;
 use PHPJava\Kernel\Types\Type;
 
 final class _dastore implements OperationInterface
@@ -23,10 +24,6 @@ final class _dastore implements OperationInterface
         $arrayref = $this->popFromOperandStack();
 
         // The value is a ref.
-        $arrayref[$index] = $value;
-
-        $this->pushToOperandStack(
-            $arrayref
-        );
+        $arrayref[$index] = _Double::get($value);
     }
 }

--- a/src/Kernel/Mnemonics/_fastore.php
+++ b/src/Kernel/Mnemonics/_fastore.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Kernel\Filters\Normalizer;
+use PHPJava\Kernel\Types\_Float;
 use PHPJava\Kernel\Types\Type;
 
 final class _fastore implements OperationInterface
@@ -20,10 +21,6 @@ final class _fastore implements OperationInterface
         $arrayref = $this->popFromOperandStack();
 
         // The value is a ref.
-        $arrayref[$index] = $value;
-
-        $this->pushToOperandStack(
-            $arrayref
-        );
+        $arrayref[$index] = _Float::get($value);
     }
 }

--- a/src/Kernel/Mnemonics/_iastore.php
+++ b/src/Kernel/Mnemonics/_iastore.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Kernel\Filters\Normalizer;
+use PHPJava\Kernel\Types\_Int;
 use PHPJava\Kernel\Types\Type;
 
 final class _iastore implements OperationInterface
@@ -20,10 +21,6 @@ final class _iastore implements OperationInterface
         $arrayref = $this->popFromOperandStack();
 
         // The value is a ref.
-        $arrayref[$index] = $value;
-
-        $this->pushToOperandStack(
-            $arrayref
-        );
+        $arrayref[$index] = _Int::get($value);
     }
 }

--- a/src/Kernel/Mnemonics/_sastore.php
+++ b/src/Kernel/Mnemonics/_sastore.php
@@ -2,6 +2,7 @@
 namespace PHPJava\Kernel\Mnemonics;
 
 use PHPJava\Kernel\Filters\Normalizer;
+use PHPJava\Kernel\Types\_Short;
 use PHPJava\Kernel\Types\Type;
 
 final class _sastore implements OperationInterface
@@ -20,10 +21,6 @@ final class _sastore implements OperationInterface
         $arrayref = $this->popFromOperandStack();
 
         // The value is a ref.
-        $arrayref[$index] = $value;
-
-        $this->pushToOperandStack(
-            $arrayref
-        );
+        $arrayref[$index] = _Short::get($value);
     }
 }

--- a/src/Kernel/Structures/_Long.php
+++ b/src/Kernel/Structures/_Long.php
@@ -14,7 +14,7 @@ class _Long implements StructureInterface
 
     public function execute(): void
     {
-        $this->bytes = $this->readLong();
+        $this->bytes = $this->readUnsignedLong();
     }
 
     public function getBytes(): int

--- a/src/Kernel/Types/_Array/Collection.php
+++ b/src/Kernel/Types/_Array/Collection.php
@@ -81,9 +81,6 @@ class Collection implements \ArrayAccess, \Countable, \IteratorAggregate
         unset($this->data[$offset]);
     }
 
-    /**
-     * @param int $offset
-     */
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {

--- a/src/Kernel/Types/_Char.php
+++ b/src/Kernel/Types/_Char.php
@@ -33,6 +33,6 @@ class _Char extends Type
         if (ctype_alpha($value) && strlen($value) === 1) {
             return $value;
         }
-        return chr($value);
+        return json_decode(sprintf('"\\u%04X"', $value));
     }
 }

--- a/src/Kernel/Types/_Long.php
+++ b/src/Kernel/Types/_Long.php
@@ -8,13 +8,18 @@ class _Long extends Type
     protected $nameInJava = 'long';
     protected $nameInPHP = 'integer';
 
-    const MIN = -9223372036854775808;
-    const MAX = 9223372036854775807;
+    const MIN = PHP_INT_MIN;
+    const MAX = PHP_INT_MAX;
 
     public static function isValid($value): bool
     {
         if (!is_scalar($value)) {
             return false;
+        }
+
+        // Adjustment negative value for PHP problems
+        if ($value === static::MIN) {
+            $value++;
         }
         if (!ctype_digit((string) abs($value))) {
             return false;

--- a/tests/AccessDynamicFieldTest.php
+++ b/tests/AccessDynamicFieldTest.php
@@ -9,14 +9,14 @@ class AccessDynamicFieldTest extends Base
 
     public function testGetPuttedField()
     {
-        $constructed = $this->initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
+        $constructed = static::$initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
         $this->assertEquals(5, $constructed->getDynamic()->getFields()->get('number')->getValue());
         $this->assertEquals('Hello World', $constructed->getDynamic()->getFields()->get('string'));
     }
 
     public function testOverwriteField()
     {
-        $constructed = $this->initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
+        $constructed = static::$initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
         $constructed->getStatic()->getFields()->set('number', 1000);
         $constructed->getStatic()->getFields()->set('string', 'New String!');
         $this->assertEquals(1000, $constructed->getStatic()->getFields()->get('number'));
@@ -25,12 +25,12 @@ class AccessDynamicFieldTest extends Base
 
     public function testAffectedNewConstructingTest()
     {
-        $constructed = $this->initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
+        $constructed = static::$initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
         $constructed->getStatic()->getFields()->set('number', 1000);
         $constructed->getStatic()->getFields()->set('string', 'New String!');
 
         // affected assertion
-        $constructed = $this->initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
+        $constructed = static::$initiatedJavaClasses['AccessDynamicFieldTest']->getInvoker()->construct();
         $this->assertEquals(5, $constructed->getDynamic()->getFields()->get('number')->getValue());
         $this->assertEquals('Hello World', $constructed->getDynamic()->getFields()->get('string'));
     }

--- a/tests/AccessDynamicMethodTest.php
+++ b/tests/AccessDynamicMethodTest.php
@@ -11,7 +11,7 @@ class AccessDynamicMethodTest extends Base
     {
         ob_start();
         // call main
-        $this->initiatedJavaClasses['AccessDynamicMethodTest']
+        static::$initiatedJavaClasses['AccessDynamicMethodTest']
             ->getInvoker()
             ->construct()
             ->getDynamic()
@@ -29,7 +29,7 @@ class AccessDynamicMethodTest extends Base
     {
         ob_start();
         // call main
-        $this->initiatedJavaClasses['AccessDynamicMethodTest']
+        static::$initiatedJavaClasses['AccessDynamicMethodTest']
             ->getInvoker()
             ->construct()
             ->getDynamic()
@@ -46,7 +46,7 @@ class AccessDynamicMethodTest extends Base
     public function testCallReturnTest()
     {
         // call main
-        $result = $this->initiatedJavaClasses['AccessDynamicMethodTest']
+        $result = static::$initiatedJavaClasses['AccessDynamicMethodTest']
             ->getInvoker()
             ->construct()
             ->getDynamic()

--- a/tests/AccessStaticFieldTest.php
+++ b/tests/AccessStaticFieldTest.php
@@ -9,13 +9,13 @@ class AccessStaticFieldTest extends Base
 
     public function testGetPuttedField()
     {
-        $this->assertEquals(5, $this->initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('number')->getValue());
-        $this->assertEquals('Hello World', $this->initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('string'));
+        $this->assertEquals(5, static::$initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('number')->getValue());
+        $this->assertEquals('Hello World', static::$initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic()->getFields()->get('string'));
     }
 
     public function testOverwriteField()
     {
-        $static = $this->initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic();
+        $static = static::$initiatedJavaClasses['AccessStaticFieldTest']->getInvoker()->getStatic();
         $static->getFields()->set('number', 1000);
         $static->getFields()->set('string', 'New String!');
         $this->assertEquals(1000, $static->getFields()->get('number'));

--- a/tests/AccessStaticMethodTest.php
+++ b/tests/AccessStaticMethodTest.php
@@ -11,7 +11,7 @@ class AccessStaticMethodTest extends Base
     {
         ob_start();
         // call main
-        $this->initiatedJavaClasses['AccessStaticMethodTest']
+        static::$initiatedJavaClasses['AccessStaticMethodTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -28,7 +28,7 @@ class AccessStaticMethodTest extends Base
     {
         ob_start();
         // call main
-        $this->initiatedJavaClasses['AccessStaticMethodTest']
+        static::$initiatedJavaClasses['AccessStaticMethodTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -44,7 +44,7 @@ class AccessStaticMethodTest extends Base
     public function testCallReturnTest()
     {
         // call main
-        $result = $this->initiatedJavaClasses['AccessStaticMethodTest']
+        $result = static::$initiatedJavaClasses['AccessStaticMethodTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/ArrayTest.php
+++ b/tests/ArrayTest.php
@@ -9,7 +9,7 @@ class ArrayTest extends Base
 
     private function call($method)
     {
-        return $this->initiatedJavaClasses['ArrayTest']
+        return static::$initiatedJavaClasses['ArrayTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/Base.php
+++ b/tests/Base.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class Base extends TestCase
 {
     protected $fixtures = [];
-    protected $initiatedJavaClasses = [];
+    protected static $initiatedJavaClasses = [];
 
     public function setUp(): void
     {
@@ -22,8 +22,11 @@ class Base extends TestCase
         ]);
 
         foreach ($this->fixtures as $fixture) {
+            if (isset(static::$initiatedJavaClasses[$fixture])) {
+                continue;
+            }
             exec('javac -classpath ' . $pathRoot . ' -encoding UTF8 ' . $pathRoot . str_replace(['../', './'], '', $fixture) . '.java -d ' . __DIR__ . '/caches');
-            $this->initiatedJavaClasses[$fixture] = JavaClass::load(
+            static::$initiatedJavaClasses[$fixture] = JavaClass::load(
                 $fixture
             );
         }

--- a/tests/BigNumberCalculationTest.php
+++ b/tests/BigNumberCalculationTest.php
@@ -12,7 +12,7 @@ class BigNumberCalculationTest extends Base
 
     private function call($method, ...$arguments)
     {
-        return $this->initiatedJavaClasses['BigNumberCalculationTest']
+        return static::$initiatedJavaClasses['BigNumberCalculationTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/BinaryOperatorTest.php
+++ b/tests/BinaryOperatorTest.php
@@ -11,7 +11,7 @@ class BinaryOperatorTest extends Base
 
     private function call($method, $value1, $value2)
     {
-        $calculatedValue = $this->initiatedJavaClasses['BinaryOperatorTest']
+        $calculatedValue = static::$initiatedJavaClasses['BinaryOperatorTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -22,7 +22,7 @@ class BinaryOperatorTest extends Base
 
     private function callWithLong($method, $value1, $value2)
     {
-        $calculatedValue = $this->initiatedJavaClasses['BinaryOperatorTest']
+        $calculatedValue = static::$initiatedJavaClasses['BinaryOperatorTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/BoundaryValueTypeForBooleanTest.php
+++ b/tests/BoundaryValueTypeForBooleanTest.php
@@ -1,0 +1,90 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForBooleanTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForBooleanTest',
+    ];
+
+    public function testStaticB0()
+    {
+        $this->assertStaticField(
+            '1',
+            'b0'
+        );
+    }
+
+    public function testStaticB1()
+    {
+        $this->assertStaticField(
+            '0',
+            'b1'
+        );
+    }
+
+    public function testDynamicB0()
+    {
+        $this->assertDynamicField(
+            '1',
+            'b0'
+        );
+    }
+
+    public function testDynamicB1()
+    {
+        $this->assertDynamicField(
+            '0',
+            'b1'
+        );
+    }
+
+    public function testStaticArrayBooleans()
+    {
+        $array = $this->getStaticField('s_a_b');
+        $this->assertCount(2, $array);
+
+        $this->assertEquals('1', (string) $array[0]);
+        $this->assertEquals('0', (string) $array[1]);
+    }
+
+    public function testDynamicArrayBooleans()
+    {
+        $array = $this->getDynamicField('d_a_b');
+        $this->assertCount(2, $array);
+
+        $this->assertEquals('1', (string) $array[0]);
+        $this->assertEquals('0', (string) $array[1]);
+    }
+
+    public function testStaticMultiDimensionArrayBooleans()
+    {
+        $array = $this->getStaticField('s_ma_b');
+        $this->assertCount(2, $array);
+        $this->assertCount(2, $array[0]);
+        $this->assertCount(2, $array[1]);
+
+        $this->assertEquals('1', (string) $array[0][0]);
+        $this->assertEquals('0', (string) $array[0][1]);
+
+        $this->assertEquals('0', (string) $array[1][0]);
+        $this->assertEquals('1', (string) $array[1][1]);
+    }
+
+    public function testDynamicMultiDimensionArrayBooleans()
+    {
+        $array = $this->getDynamicField('d_ma_b');
+        $this->assertCount(2, $array);
+        $this->assertCount(2, $array[0]);
+        $this->assertCount(2, $array[1]);
+
+        $this->assertEquals('1', (string) $array[0][0]);
+        $this->assertEquals('0', (string) $array[0][1]);
+
+        $this->assertEquals('0', (string) $array[1][0]);
+        $this->assertEquals('1', (string) $array[1][1]);
+    }
+}

--- a/tests/BoundaryValueTypeForByteTest.php
+++ b/tests/BoundaryValueTypeForByteTest.php
@@ -1,0 +1,186 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForByteTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForByteTest',
+    ];
+
+    public function testStaticBy0()
+    {
+        $this->assertStaticField(
+            '0',
+            'by0'
+        );
+    }
+
+    public function testStaticBy1()
+    {
+        $this->assertStaticField(
+            '127',
+            'by1'
+        );
+    }
+
+    public function testStaticBy2()
+    {
+        $this->assertStaticField(
+            '18',
+            'by2'
+        );
+    }
+
+    public function testStaticBy3()
+    {
+        $this->assertStaticField(
+            '-1',
+            'by3'
+        );
+    }
+
+    public function testStaticBy4()
+    {
+        $this->assertStaticField(
+            '-127',
+            'by4'
+        );
+    }
+
+    public function testStaticBy5()
+    {
+        $this->assertStaticField(
+            '-18',
+            'by5'
+        );
+    }
+
+    public function testStaticBy6()
+    {
+        $this->assertStaticField(
+            '-128',
+            'by6'
+        );
+    }
+
+    public function testDynamicBy0()
+    {
+        $this->assertDynamicField(
+            '0',
+            'by0'
+        );
+    }
+
+    public function testDynamicBy1()
+    {
+        $this->assertDynamicField(
+            '127',
+            'by1'
+        );
+    }
+
+    public function testDynamicBy2()
+    {
+        $this->assertDynamicField(
+            '18',
+            'by2'
+        );
+    }
+
+    public function testDynamicBy3()
+    {
+        $this->assertDynamicField(
+            '-1',
+            'by3'
+        );
+    }
+
+    public function testDynamicBy4()
+    {
+        $this->assertDynamicField(
+            '-127',
+            'by4'
+        );
+    }
+
+    public function testDynamicBy5()
+    {
+        $this->assertDynamicField(
+            '-18',
+            'by5'
+        );
+    }
+
+    public function testDynamicBy6()
+    {
+        $this->assertDynamicField(
+            '-128',
+            'by6'
+        );
+    }
+
+    public function testStaticArrayBytes()
+    {
+        $array = $this->getStaticField('s_a_by');
+        $this->assertCount(7, $array);
+
+        $this->assertEquals('0', (string) $array[0]);
+        $this->assertEquals('127', (string) $array[1]);
+        $this->assertEquals('18', (string) $array[2]);
+        $this->assertEquals('-1', (string) $array[3]);
+        $this->assertEquals('-127', (string) $array[4]);
+        $this->assertEquals('-18', (string) $array[5]);
+        $this->assertEquals('-128', (string) $array[6]);
+    }
+
+    public function testDynamicArrayBytes()
+    {
+        $array = $this->getDynamicField('d_a_by');
+        $this->assertCount(7, $array);
+
+        $this->assertEquals('0', (string) $array[0]);
+        $this->assertEquals('127', (string) $array[1]);
+        $this->assertEquals('18', (string) $array[2]);
+        $this->assertEquals('-1', (string) $array[3]);
+        $this->assertEquals('-127', (string) $array[4]);
+        $this->assertEquals('-18', (string) $array[5]);
+        $this->assertEquals('-128', (string) $array[6]);
+    }
+
+    public function testStaticMultiDimensionArrayBytes()
+    {
+        $array = $this->getStaticField('s_ma_by');
+        $this->assertCount(2, $array);
+        $this->assertCount(3, $array[0]);
+        $this->assertCount(4, $array[1]);
+
+        $this->assertEquals('0', (string) $array[0][0]);
+        $this->assertEquals('127', (string) $array[0][1]);
+        $this->assertEquals('18', (string) $array[0][2]);
+
+        $this->assertEquals('-1', (string) $array[1][0]);
+        $this->assertEquals('-127', (string) $array[1][1]);
+        $this->assertEquals('-18', (string) $array[1][2]);
+        $this->assertEquals('-128', (string) $array[1][3]);
+    }
+
+    public function testDynamicMultiDimensionArrayBytes()
+    {
+        $array = $this->getDynamicField('d_ma_by');
+        $this->assertCount(2, $array);
+        $this->assertCount(3, $array[0]);
+        $this->assertCount(4, $array[1]);
+
+        $this->assertEquals('0', (string) $array[0][0]);
+        $this->assertEquals('127', (string) $array[0][1]);
+        $this->assertEquals('18', (string) $array[0][2]);
+
+        $this->assertEquals('-1', (string) $array[1][0]);
+        $this->assertEquals('-127', (string) $array[1][1]);
+        $this->assertEquals('-18', (string) $array[1][2]);
+        $this->assertEquals('-128', (string) $array[1][3]);
+    }
+}

--- a/tests/BoundaryValueTypeForCharTest.php
+++ b/tests/BoundaryValueTypeForCharTest.php
@@ -1,0 +1,146 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForCharTest extends Base
+{
+    use Helpers\MakeUnicodeChar;
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForCharTest',
+    ];
+
+    // TODO: Fix integer to char value
+    public function testStaticC0()
+    {
+        $this->assertStaticField(
+            '0',
+            'c0'
+        );
+    }
+
+    public function testStaticC1()
+    {
+        $this->assertStaticField(
+            '65535',
+            'c1'
+        );
+    }
+
+    public function testStaticC2()
+    {
+        $this->assertStaticField(
+            '32767',
+            'c2'
+        );
+    }
+
+    public function testStaticC3()
+    {
+        $this->assertStaticField(
+            '32768',
+            'c3'
+        );
+    }
+
+    public function testStaticC4()
+    {
+        $this->assertStaticField(
+            '37155',
+            'c4'
+        );
+    }
+
+    public function testDynamicC0()
+    {
+        $this->assertDynamicField(
+            '0',
+            'c0'
+        );
+    }
+
+    public function testDynamicC1()
+    {
+        $this->assertDynamicField(
+            '65535',
+            'c1'
+        );
+    }
+
+    public function testDynamicC2()
+    {
+        $this->assertDynamicField(
+            '32767',
+            'c2'
+        );
+    }
+
+    public function testDynamicC3()
+    {
+        $this->assertDynamicField(
+            '32768',
+            'c3'
+        );
+    }
+
+    public function testDynamicC4()
+    {
+        $this->assertDynamicField(
+            '37155',
+            'c4'
+        );
+    }
+
+    public function testStaticArrayChars()
+    {
+        $array = $this->getStaticField('s_a_c');
+        $this->assertCount(5, $array);
+
+        $this->assertEquals($this->makeUnicodeChar(0x0000), (string) $array[0]);
+        $this->assertEquals($this->makeUnicodeChar(0xFFFF), (string) $array[1]);
+        $this->assertEquals($this->makeUnicodeChar(0x7FFF), (string) $array[2]);
+        $this->assertEquals($this->makeUnicodeChar(0x8000), (string) $array[3]);
+        $this->assertEquals($this->makeUnicodeChar(0x9123), (string) $array[4]);
+    }
+
+    public function testDynamicArrayChars()
+    {
+        $array = $this->getDynamicField('d_a_c');
+        $this->assertCount(5, $array);
+
+        $this->assertEquals($this->makeUnicodeChar(0x0000), (string) $array[0]);
+        $this->assertEquals($this->makeUnicodeChar(0xFFFF), (string) $array[1]);
+        $this->assertEquals($this->makeUnicodeChar(0x7FFF), (string) $array[2]);
+        $this->assertEquals($this->makeUnicodeChar(0x8000), (string) $array[3]);
+        $this->assertEquals($this->makeUnicodeChar(0x9123), (string) $array[4]);
+    }
+
+    public function testStaticMultiDimensionArrayChars()
+    {
+        $array = $this->getStaticField('s_ma_c');
+        $this->assertCount(2, $array);
+        $this->assertCount(3, $array[0]);
+        $this->assertCount(2, $array[1]);
+
+        $this->assertEquals($this->makeUnicodeChar(0x0000), (string) $array[0][0]);
+        $this->assertEquals($this->makeUnicodeChar(0xFFFF), (string) $array[0][1]);
+        $this->assertEquals($this->makeUnicodeChar(0x7FFF), (string) $array[0][2]);
+        $this->assertEquals($this->makeUnicodeChar(0x8000), (string) $array[1][0]);
+        $this->assertEquals($this->makeUnicodeChar(0x9123), (string) $array[1][1]);
+    }
+
+    public function testDynamicMultiDimensionArrayChars()
+    {
+        $array = $this->getDynamicField('d_ma_c');
+        $this->assertCount(2, $array);
+        $this->assertCount(3, $array[0]);
+        $this->assertCount(2, $array[1]);
+
+        $this->assertEquals($this->makeUnicodeChar(0x0000), (string) $array[0][0]);
+        $this->assertEquals($this->makeUnicodeChar(0xFFFF), (string) $array[0][1]);
+        $this->assertEquals($this->makeUnicodeChar(0x7FFF), (string) $array[0][2]);
+        $this->assertEquals($this->makeUnicodeChar(0x8000), (string) $array[1][0]);
+        $this->assertEquals($this->makeUnicodeChar(0x9123), (string) $array[1][1]);
+    }
+}

--- a/tests/BoundaryValueTypeForDoubleTest.php
+++ b/tests/BoundaryValueTypeForDoubleTest.php
@@ -1,0 +1,378 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForDoubleTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForDoubleTest',
+    ];
+
+    public function testStaticD0()
+    {
+        $this->assertStaticField(
+            '0',
+            'd0'
+        );
+    }
+
+    public function testStaticD1()
+    {
+        $this->assertStaticField(
+            '1234',
+            'd1'
+        );
+    }
+
+    public function testStaticD2()
+    {
+        $this->assertStaticField(
+            '0.1234',
+            'd2'
+        );
+    }
+
+    public function testStaticD3()
+    {
+        $this->assertStaticField(
+            '1234',
+            'd3'
+        );
+    }
+
+    public function testStaticD4()
+    {
+        $this->assertStaticField(
+            '1234.1234',
+            'd4'
+        );
+    }
+
+    public function testStaticD5()
+    {
+        $this->assertStaticField(
+            '-1234',
+            'd5'
+        );
+    }
+
+    public function testStaticD6()
+    {
+        $this->assertStaticField(
+            '-0.1234',
+            'd6'
+        );
+    }
+
+    public function testStaticD7()
+    {
+        $this->assertStaticField(
+            '-1234',
+            'd7'
+        );
+    }
+
+    public function testStaticD8()
+    {
+        $this->assertStaticField(
+            '-1234.1234',
+            'd8'
+        );
+    }
+
+    public function testStaticD9()
+    {
+        $this->assertStaticField(
+            '2139095039',
+            'd9'
+        );
+    }
+
+    public function testStaticD10()
+    {
+        $this->assertStaticField(
+            '-2139095039',
+            'd10'
+        );
+    }
+
+    public function testStaticD11()
+    {
+        $this->assertStaticField(
+            '-8388609',
+            'd11'
+        );
+    }
+
+    public function testStaticD12()
+    {
+        $this->assertStaticField(
+            '8388609',
+            'd12'
+        );
+    }
+
+    public function testStaticD13()
+    {
+        $this->assertStaticField(
+            '-4.5035996273705E+15',
+            'd13'
+        );
+    }
+
+    public function testStaticD14()
+    {
+        $this->assertStaticField(
+            '4.5035996273705E+15',
+            'd14'
+        );
+    }
+
+    public function testStaticD15()
+    {
+        $this->assertStaticField(
+            '9.2188684372274E+18',
+            'd15'
+        );
+    }
+
+    public function testStaticD16()
+    {
+        $this->assertStaticField(
+            '-9.2188684372274E+18',
+            'd16'
+        );
+    }
+
+    public function testDynamicD1()
+    {
+        $this->assertDynamicField(
+            '1234',
+            'd1'
+        );
+    }
+
+    public function testDynamicD2()
+    {
+        $this->assertDynamicField(
+            '0.1234',
+            'd2'
+        );
+    }
+
+    public function testDynamicD3()
+    {
+        $this->assertDynamicField(
+            '1234',
+            'd3'
+        );
+    }
+
+    public function testDynamicD4()
+    {
+        $this->assertDynamicField(
+            '1234.1234',
+            'd4'
+        );
+    }
+
+    public function testDynamicD5()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            'd5'
+        );
+    }
+
+    public function testDynamicD6()
+    {
+        $this->assertDynamicField(
+            '-0.1234',
+            'd6'
+        );
+    }
+
+    public function testDynamicD7()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            'd7'
+        );
+    }
+
+    public function testDynamicD8()
+    {
+        $this->assertDynamicField(
+            '-1234.1234',
+            'd8'
+        );
+    }
+
+    public function testDynamicD9()
+    {
+        $this->assertDynamicField(
+            '2139095039',
+            'd9'
+        );
+    }
+
+    public function testDynamicD10()
+    {
+        $this->assertDynamicField(
+            '-2139095039',
+            'd10'
+        );
+    }
+
+    public function testDynamicD11()
+    {
+        $this->assertDynamicField(
+            '-8388609',
+            'd11'
+        );
+    }
+
+    public function testDynamicD12()
+    {
+        $this->assertDynamicField(
+            '8388609',
+            'd12'
+        );
+    }
+
+    public function testDynamicD13()
+    {
+        $this->assertDynamicField(
+            '-4.5035996273705E+15',
+            'd13'
+        );
+    }
+
+    public function testDynamicD14()
+    {
+        $this->assertDynamicField(
+            '4.5035996273705E+15',
+            'd14'
+        );
+    }
+
+    public function testDynamicD15()
+    {
+        $this->assertDynamicField(
+            '9.2188684372274E+18',
+            'd15'
+        );
+    }
+
+    public function testDynamicD16()
+    {
+        $this->assertDynamicField(
+            '-9.2188684372274E+18',
+            'd16'
+        );
+    }
+
+    public function testStaticArrayDoubles()
+    {
+        $array = $this->getStaticField('s_a_d');
+        $this->assertCount(17, $array);
+
+        $this->assertEquals('0', (string) $array[0]);
+        $this->assertEquals('1234', (string) $array[1]);
+        $this->assertEquals('0.1234', (string) $array[2]);
+        $this->assertEquals('1234', (string) $array[3]);
+        $this->assertEquals('1234.1234', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-0.1234', (string) $array[6]);
+        $this->assertEquals('-1234', (string) $array[7]);
+        $this->assertEquals('-1234.1234', (string) $array[8]);
+        $this->assertEquals('2139095039', (string) $array[9]);
+        $this->assertEquals('-2139095039', (string) $array[10]);
+        $this->assertEquals('-8388609', (string) $array[11]);
+        $this->assertEquals('8388609', (string) $array[12]);
+        $this->assertEquals('-4.5035996273705E+15', (string) $array[13]);
+        $this->assertEquals('4.5035996273705E+15', (string) $array[14]);
+        $this->assertEquals('9.2188684372274E+18', (string) $array[15]);
+        $this->assertEquals('-9.2188684372274E+18', (string) $array[16]);
+    }
+
+    public function testDynamicArrayDoubles()
+    {
+        $array = $this->getDynamicField('d_a_d');
+        $this->assertCount(17, $array);
+
+        $this->assertEquals('0', (string) $array[0]);
+        $this->assertEquals('1234', (string) $array[1]);
+        $this->assertEquals('0.1234', (string) $array[2]);
+        $this->assertEquals('1234', (string) $array[3]);
+        $this->assertEquals('1234.1234', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-0.1234', (string) $array[6]);
+        $this->assertEquals('-1234', (string) $array[7]);
+        $this->assertEquals('-1234.1234', (string) $array[8]);
+        $this->assertEquals('2139095039', (string) $array[9]);
+        $this->assertEquals('-2139095039', (string) $array[10]);
+        $this->assertEquals('-8388609', (string) $array[11]);
+        $this->assertEquals('8388609', (string) $array[12]);
+        $this->assertEquals('-4.5035996273705E+15', (string) $array[13]);
+        $this->assertEquals('4.5035996273705E+15', (string) $array[14]);
+        $this->assertEquals('9.2188684372274E+18', (string) $array[15]);
+        $this->assertEquals('-9.2188684372274E+18', (string) $array[16]);
+    }
+
+    public function testStaticMultiDimensionArrayDoubles()
+    {
+        $array = $this->getStaticField('s_ma_d');
+        $this->assertCount(2, $array);
+        $this->assertCount(8, $array[0]);
+        $this->assertCount(9, $array[1]);
+
+        $this->assertEquals('0', (string) $array[0][0]);
+        $this->assertEquals('1234', (string) $array[0][1]);
+        $this->assertEquals('0.1234', (string) $array[0][2]);
+        $this->assertEquals('1234', (string) $array[0][3]);
+        $this->assertEquals('1234.1234', (string) $array[0][4]);
+        $this->assertEquals('-1234', (string) $array[0][5]);
+        $this->assertEquals('-4.5035996273705E+15', (string) $array[0][6]);
+        $this->assertEquals('4.5035996273705E+15', (string) $array[0][7]);
+
+        $this->assertEquals('-0.1234', (string) $array[1][0]);
+        $this->assertEquals('-1234', (string) $array[1][1]);
+        $this->assertEquals('-1234.1234', (string) $array[1][2]);
+        $this->assertEquals('2139095039', (string) $array[1][3]);
+        $this->assertEquals('-2139095039', (string) $array[1][4]);
+        $this->assertEquals('-8388609', (string) $array[1][5]);
+        $this->assertEquals('8388609', (string) $array[1][6]);
+        $this->assertEquals('9.2188684372274E+18', (string) $array[1][7]);
+        $this->assertEquals('-9.2188684372274E+18', (string) $array[1][8]);
+    }
+
+    public function testDynamicMultiDimensionArrayDoubles()
+    {
+        $array = $this->getDynamicField('d_ma_d');
+        $this->assertCount(2, $array);
+        $this->assertCount(8, $array[0]);
+        $this->assertCount(9, $array[1]);
+
+        $this->assertEquals('0', (string) $array[0][0]);
+        $this->assertEquals('1234', (string) $array[0][1]);
+        $this->assertEquals('0.1234', (string) $array[0][2]);
+        $this->assertEquals('1234', (string) $array[0][3]);
+        $this->assertEquals('1234.1234', (string) $array[0][4]);
+        $this->assertEquals('-1234', (string) $array[0][5]);
+        $this->assertEquals('-4.5035996273705E+15', (string) $array[0][6]);
+        $this->assertEquals('4.5035996273705E+15', (string) $array[0][7]);
+
+        $this->assertEquals('-0.1234', (string) $array[1][0]);
+        $this->assertEquals('-1234', (string) $array[1][1]);
+        $this->assertEquals('-1234.1234', (string) $array[1][2]);
+        $this->assertEquals('2139095039', (string) $array[1][3]);
+        $this->assertEquals('-2139095039', (string) $array[1][4]);
+        $this->assertEquals('-8388609', (string) $array[1][5]);
+        $this->assertEquals('8388609', (string) $array[1][6]);
+        $this->assertEquals('9.2188684372274E+18', (string) $array[1][7]);
+        $this->assertEquals('-9.2188684372274E+18', (string) $array[1][8]);
+    }
+}

--- a/tests/BoundaryValueTypeForFloatTest.php
+++ b/tests/BoundaryValueTypeForFloatTest.php
@@ -1,0 +1,304 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForFloatTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForFloatTest',
+    ];
+
+    public function testStaticF0()
+    {
+        $this->assertStaticField(
+            '0',
+            'f0'
+        );
+    }
+
+    public function testStaticF1()
+    {
+        $this->assertStaticField(
+            '1234',
+            'f1'
+        );
+    }
+
+    public function testStaticF2()
+    {
+        $this->assertStaticField(
+            '0.12340000271797',
+            'f2'
+        );
+    }
+
+    public function testStaticF3()
+    {
+        $this->assertStaticField(
+            '1234',
+            'f3'
+        );
+    }
+
+    public function testStaticF4()
+    {
+        $this->assertStaticField(
+            '1234.1234130859',
+            'f4'
+        );
+    }
+
+    public function testStaticF5()
+    {
+        $this->assertStaticField(
+            '-1234',
+            'f5'
+        );
+    }
+
+    public function testStaticF6()
+    {
+        $this->assertStaticField(
+            '-0.12340000271797',
+            'f6'
+        );
+    }
+
+    public function testStaticF7()
+    {
+        $this->assertStaticField(
+            '-1234',
+            'f7'
+        );
+    }
+
+    public function testStaticF8()
+    {
+        $this->assertStaticField(
+            '-1234.1234130859',
+            'f8'
+        );
+    }
+
+    public function testStaticF9()
+    {
+        $this->assertStaticField(
+            '2139095040',
+            'f9'
+        );
+    }
+
+    public function testStaticF10()
+    {
+        $this->assertStaticField(
+            '-2139095040',
+            'f10'
+        );
+    }
+
+    public function testStaticF11()
+    {
+        $this->assertStaticField(
+            '-8388609',
+            'f11'
+        );
+    }
+
+    public function testStaticF12()
+    {
+        $this->assertStaticField(
+            '8388609',
+            'f12'
+        );
+    }
+
+    public function testDynamicF0()
+    {
+        $this->assertDynamicField(
+            '0',
+            'f0'
+        );
+    }
+
+    public function testDynamicF1()
+    {
+        $this->assertDynamicField(
+            '1234',
+            'f1'
+        );
+    }
+
+    public function testDynamicF2()
+    {
+        $this->assertDynamicField(
+            '0.12340000271797',
+            'f2'
+        );
+    }
+
+    public function testDynamicF3()
+    {
+        $this->assertDynamicField(
+            '1234',
+            'f3'
+        );
+    }
+
+    public function testDynamicF4()
+    {
+        $this->assertDynamicField(
+            '1234.1234130859',
+            'f4'
+        );
+    }
+
+    public function testDynamicF5()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            'f5'
+        );
+    }
+
+    public function testDynamicF6()
+    {
+        $this->assertDynamicField(
+            '-0.12340000271797',
+            'f6'
+        );
+    }
+
+    public function testDynamicF7()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            'f7'
+        );
+    }
+
+    public function testDynamicF8()
+    {
+        $this->assertDynamicField(
+            '-1234.1234130859',
+            'f8'
+        );
+    }
+
+    public function testDynamicF9()
+    {
+        $this->assertDynamicField(
+            '2139095040',
+            'f9'
+        );
+    }
+
+    public function testDynamicF10()
+    {
+        $this->assertDynamicField(
+            '-2139095040',
+            'f10'
+        );
+    }
+
+    public function testDynamicF11()
+    {
+        $this->assertDynamicField(
+            '-8388609',
+            'f11'
+        );
+    }
+
+    public function testDynamicF12()
+    {
+        $this->assertDynamicField(
+            '8388609',
+            'f12'
+        );
+    }
+
+    public function testStaticArrayFloats()
+    {
+        $array = $this->getStaticField('s_a_f');
+        $this->assertCount(13, $array);
+
+        $this->assertEquals('0', (string) $array[0]);
+        $this->assertEquals('1234', (string) $array[1]);
+        $this->assertEquals('0.12340000271797', (string) $array[2]);
+        $this->assertEquals('1234', (string) $array[3]);
+        $this->assertEquals('1234.1234130859', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-0.12340000271797', (string) $array[6]);
+        $this->assertEquals('-1234', (string) $array[7]);
+        $this->assertEquals('-1234.1234130859', (string) $array[8]);
+        $this->assertEquals('2139095040', (string) $array[9]);
+        $this->assertEquals('-2139095040', (string) $array[10]);
+        $this->assertEquals('-8388609', (string) $array[11]);
+        $this->assertEquals('8388609', (string) $array[12]);
+    }
+
+    public function testDynamicArrayFloats()
+    {
+        $array = $this->getDynamicField('d_a_f');
+        $this->assertCount(13, $array);
+
+        $this->assertEquals('0', (string) $array[0]);
+        $this->assertEquals('1234', (string) $array[1]);
+        $this->assertEquals('0.12340000271797', (string) $array[2]);
+        $this->assertEquals('1234', (string) $array[3]);
+        $this->assertEquals('1234.1234130859', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-0.12340000271797', (string) $array[6]);
+        $this->assertEquals('-1234', (string) $array[7]);
+        $this->assertEquals('-1234.1234130859', (string) $array[8]);
+        $this->assertEquals('2139095040', (string) $array[9]);
+        $this->assertEquals('-2139095040', (string) $array[10]);
+        $this->assertEquals('-8388609', (string) $array[11]);
+        $this->assertEquals('8388609', (string) $array[12]);
+    }
+
+    public function testStaticMultiDimensionArrayFloats()
+    {
+        $array = $this->getStaticField('s_ma_f');
+        $this->assertCount(2, $array);
+        $this->assertCount(6, $array[0]);
+        $this->assertCount(7, $array[1]);
+
+        $this->assertEquals('0', (string) $array[0][0]);
+        $this->assertEquals('1234', (string) $array[0][1]);
+        $this->assertEquals('0.12340000271797', (string) $array[0][2]);
+        $this->assertEquals('1234', (string) $array[0][3]);
+        $this->assertEquals('1234.1234130859', (string) $array[0][4]);
+        $this->assertEquals('-1234', (string) $array[0][5]);
+        $this->assertEquals('-0.12340000271797', (string) $array[1][0]);
+        $this->assertEquals('-1234', (string) $array[1][1]);
+        $this->assertEquals('-1234.1234130859', (string) $array[1][2]);
+        $this->assertEquals('2139095040', (string) $array[1][3]);
+        $this->assertEquals('-2139095040', (string) $array[1][4]);
+        $this->assertEquals('-8388609', (string) $array[1][5]);
+        $this->assertEquals('8388609', (string) $array[1][6]);
+    }
+
+    public function testDynamicMultiDimensionArrayFloats()
+    {
+        $array = $this->getDynamicField('d_ma_f');
+        $this->assertCount(2, $array);
+        $this->assertCount(6, $array[0]);
+        $this->assertCount(7, $array[1]);
+
+        $this->assertEquals('0', (string) $array[0][0]);
+        $this->assertEquals('1234', (string) $array[0][1]);
+        $this->assertEquals('0.12340000271797', (string) $array[0][2]);
+        $this->assertEquals('1234', (string) $array[0][3]);
+        $this->assertEquals('1234.1234130859', (string) $array[0][4]);
+        $this->assertEquals('-1234', (string) $array[0][5]);
+        $this->assertEquals('-0.12340000271797', (string) $array[1][0]);
+        $this->assertEquals('-1234', (string) $array[1][1]);
+        $this->assertEquals('-1234.1234130859', (string) $array[1][2]);
+        $this->assertEquals('2139095040', (string) $array[1][3]);
+        $this->assertEquals('-2139095040', (string) $array[1][4]);
+        $this->assertEquals('-8388609', (string) $array[1][5]);
+        $this->assertEquals('8388609', (string) $array[1][6]);
+    }
+}

--- a/tests/BoundaryValueTypeForIntTest.php
+++ b/tests/BoundaryValueTypeForIntTest.php
@@ -1,0 +1,224 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForIntTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForIntTest',
+    ];
+
+    public function testStaticI0()
+    {
+        $this->assertStaticField(
+            '1234',
+            'i0'
+        );
+    }
+
+    public function testStaticI1()
+    {
+        $this->assertStaticField(
+            '32767',
+            'i1'
+        );
+    }
+
+    public function testStaticI2()
+    {
+        $this->assertStaticField(
+            '32768',
+            'i2'
+        );
+    }
+
+    public function testStaticI3()
+    {
+        $this->assertStaticField(
+            '2147483647',
+            'i3'
+        );
+    }
+
+    public function testStaticI4()
+    {
+        $this->assertStaticField(
+            '-1',
+            'i4'
+        );
+    }
+
+    public function testStaticI5()
+    {
+        $this->assertStaticField(
+            '-1234',
+            'i5'
+        );
+    }
+
+    public function testStaticI6()
+    {
+        $this->assertStaticField(
+            '-2147483648',
+            'i6'
+        );
+    }
+
+    public function testStaticI7()
+    {
+        $this->assertStaticField(
+            '-32768',
+            'i7'
+        );
+    }
+
+    public function testStaticI8()
+    {
+        $this->assertStaticField(
+            '0',
+            'i8'
+        );
+    }
+
+    public function testDynamicI0()
+    {
+        $this->assertDynamicField(
+            '1234',
+            'i0'
+        );
+    }
+
+    public function testDynamicI1()
+    {
+        $this->assertDynamicField(
+            '32767',
+            'i1'
+        );
+    }
+
+    public function testDynamicI2()
+    {
+        $this->assertDynamicField(
+            '32768',
+            'i2'
+        );
+    }
+
+    public function testDynamicI3()
+    {
+        $this->assertDynamicField(
+            '2147483647',
+            'i3'
+        );
+    }
+
+    public function testDynamicI4()
+    {
+        $this->assertDynamicField(
+            '-1',
+            'i4'
+        );
+    }
+
+    public function testDynamicI5()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            'i5'
+        );
+    }
+
+    public function testDynamicI6()
+    {
+        $this->assertDynamicField(
+            '-2147483648',
+            'i6'
+        );
+    }
+
+    public function testDynamicI7()
+    {
+        $this->assertDynamicField(
+            '-32768',
+            'i7'
+        );
+    }
+
+    public function testDynamicI8()
+    {
+        $this->assertDynamicField(
+            '0',
+            'i8'
+        );
+    }
+
+    public function testStaticArrayIntegers()
+    {
+        $array = $this->getStaticField('s_a_i');
+        $this->assertCount(9, $array);
+
+        $this->assertEquals('1234', (string) $array[0]);
+        $this->assertEquals('32767', (string) $array[1]);
+        $this->assertEquals('32768', (string) $array[2]);
+        $this->assertEquals('2147483647', (string) $array[3]);
+        $this->assertEquals('-1', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-2147483648', (string) $array[6]);
+        $this->assertEquals('-32768', (string) $array[7]);
+        $this->assertEquals('0', (string) $array[8]);
+    }
+
+    public function testDynamicArrayIntegers()
+    {
+        $array = $this->getDynamicField('d_a_i');
+        $this->assertCount(9, $array);
+
+        $this->assertEquals('1234', (string) $array[0]);
+        $this->assertEquals('32767', (string) $array[1]);
+        $this->assertEquals('32768', (string) $array[2]);
+        $this->assertEquals('2147483647', (string) $array[3]);
+        $this->assertEquals('-1', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-2147483648', (string) $array[6]);
+        $this->assertEquals('-32768', (string) $array[7]);
+        $this->assertEquals('0', (string) $array[8]);
+    }
+
+    public function testStaticMultiDimensionArrayIntegers()
+    {
+        $array = $this->getStaticField('s_ma_i');
+        $this->assertCount(2, $array);
+        $this->assertCount(4, $array[0]);
+        $this->assertCount(5, $array[1]);
+
+        $this->assertEquals('1234', (string) $array[0][0]);
+        $this->assertEquals('32767', (string) $array[0][1]);
+        $this->assertEquals('32768', (string) $array[0][2]);
+        $this->assertEquals('2147483647', (string) $array[0][3]);
+        $this->assertEquals('-1', (string) $array[1][0]);
+        $this->assertEquals('-1234', (string) $array[1][1]);
+        $this->assertEquals('-2147483648', (string) $array[1][2]);
+        $this->assertEquals('-32768', (string) $array[1][3]);
+        $this->assertEquals('0', (string) $array[1][4]);
+    }
+
+    public function testDynamicMultiDimensionArrayIntegers()
+    {
+        $array = $this->getDynamicField('d_ma_i');
+        $this->assertCount(2, $array);
+        $this->assertCount(4, $array[0]);
+        $this->assertCount(5, $array[1]);
+
+        $this->assertEquals('1234', (string) $array[0][0]);
+        $this->assertEquals('32767', (string) $array[0][1]);
+        $this->assertEquals('32768', (string) $array[0][2]);
+        $this->assertEquals('2147483647', (string) $array[0][3]);
+        $this->assertEquals('-1', (string) $array[1][0]);
+        $this->assertEquals('-1234', (string) $array[1][1]);
+        $this->assertEquals('-2147483648', (string) $array[1][2]);
+        $this->assertEquals('-32768', (string) $array[1][3]);
+        $this->assertEquals('0', (string) $array[1][4]);
+    }
+}

--- a/tests/BoundaryValueTypeForLongTest.php
+++ b/tests/BoundaryValueTypeForLongTest.php
@@ -1,0 +1,266 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForLongTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForLongTest',
+    ];
+
+    public function testStaticL0()
+    {
+        $this->assertStaticField(
+            '1234',
+            'l0'
+        );
+    }
+
+    public function testStaticL1()
+    {
+        $this->assertStaticField(
+            '32767',
+            'l1'
+        );
+    }
+
+    public function testStaticL2()
+    {
+        $this->assertStaticField(
+            '32768',
+            'l2'
+        );
+    }
+
+    public function testStaticL3()
+    {
+        $this->assertStaticField(
+            '2147483647',
+            'l3'
+        );
+    }
+
+    public function testStaticL4()
+    {
+        $this->assertStaticField(
+            '-1',
+            'l4'
+        );
+    }
+
+    public function testStaticL5()
+    {
+        $this->assertStaticField(
+            '-1234',
+            'l5'
+        );
+    }
+
+    public function testStaticL6()
+    {
+        $this->assertStaticField(
+            '-2147483648',
+            'l6'
+        );
+    }
+
+    public function testStaticL7()
+    {
+        $this->assertStaticField(
+            '-32768',
+            'l7'
+        );
+    }
+
+    public function testStaticL8()
+    {
+        $this->assertStaticField(
+            '-9223372036854775808',
+            'l8'
+        );
+    }
+
+    public function testStaticL9()
+    {
+        $this->assertStaticField(
+            '9223372036854775807',
+            'l9'
+        );
+    }
+
+    public function testStaticL10()
+    {
+        $this->assertStaticField(
+            '0',
+            'l10'
+        );
+    }
+
+    public function testDynamicL0()
+    {
+        $this->assertDynamicField(
+            '1234',
+            'l0'
+        );
+    }
+
+    public function testDynamicL1()
+    {
+        $this->assertDynamicField(
+            '32767',
+            'l1'
+        );
+    }
+
+    public function testDynamicL2()
+    {
+        $this->assertDynamicField(
+            '32768',
+            'l2'
+        );
+    }
+
+    public function testDynamicL3()
+    {
+        $this->assertDynamicField(
+            '2147483647',
+            'l3'
+        );
+    }
+
+    public function testDynamicL4()
+    {
+        $this->assertDynamicField(
+            '-1',
+            'l4'
+        );
+    }
+
+    public function testDynamicL5()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            'l5'
+        );
+    }
+
+    public function testDynamicL6()
+    {
+        $this->assertDynamicField(
+            '-2147483648',
+            'l6'
+        );
+    }
+
+    public function testDynamicL7()
+    {
+        $this->assertDynamicField(
+            '-32768',
+            'l7'
+        );
+    }
+
+    public function testDynamicL8()
+    {
+        $this->assertDynamicField(
+            '-9223372036854775808',
+            'l8'
+        );
+    }
+
+    public function testDynamicL9()
+    {
+        $this->assertDynamicField(
+            '9223372036854775807',
+            'l9'
+        );
+    }
+
+    public function testDynamicL10()
+    {
+        $this->assertDynamicField(
+            '0',
+            'l10'
+        );
+    }
+
+    public function testStaticArrayLongs()
+    {
+        $array = $this->getStaticField('s_a_l');
+        $this->assertCount(11, $array);
+
+        $this->assertEquals('1234', (string) $array[0]);
+        $this->assertEquals('32767', (string) $array[1]);
+        $this->assertEquals('32768', (string) $array[2]);
+        $this->assertEquals('2147483647', (string) $array[3]);
+        $this->assertEquals('-1', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-2147483648', (string) $array[6]);
+        $this->assertEquals('-32768', (string) $array[7]);
+        $this->assertEquals('-9223372036854775808', (string) $array[8]);
+        $this->assertEquals('9223372036854775807', (string) $array[9]);
+        $this->assertEquals('0', (string) $array[10]);
+    }
+
+    public function testDynamicArrayLongs()
+    {
+        $array = $this->getDynamicField('d_a_l');
+        $this->assertCount(11, $array);
+
+        $this->assertEquals('1234', (string) $array[0]);
+        $this->assertEquals('32767', (string) $array[1]);
+        $this->assertEquals('32768', (string) $array[2]);
+        $this->assertEquals('2147483647', (string) $array[3]);
+        $this->assertEquals('-1', (string) $array[4]);
+        $this->assertEquals('-1234', (string) $array[5]);
+        $this->assertEquals('-2147483648', (string) $array[6]);
+        $this->assertEquals('-32768', (string) $array[7]);
+        $this->assertEquals('-9223372036854775808', (string) $array[8]);
+        $this->assertEquals('9223372036854775807', (string) $array[9]);
+        $this->assertEquals('0', (string) $array[10]);
+    }
+
+    public function testStaticMultiDimensionArrayLongs()
+    {
+        $array = $this->getStaticField('s_ma_l');
+        $this->assertCount(2, $array);
+        $this->assertCount(6, $array[0]);
+        $this->assertCount(5, $array[1]);
+
+        $this->assertEquals('1234', (string) $array[0][0]);
+        $this->assertEquals('32767', (string) $array[0][1]);
+        $this->assertEquals('32768', (string) $array[0][2]);
+        $this->assertEquals('2147483647', (string) $array[0][3]);
+        $this->assertEquals('-1', (string) $array[0][4]);
+        $this->assertEquals('-1234', (string) $array[0][5]);
+
+        $this->assertEquals('-2147483648', (string) $array[1][0]);
+        $this->assertEquals('-32768', (string) $array[1][1]);
+        $this->assertEquals('-9223372036854775808', (string) $array[1][2]);
+        $this->assertEquals('9223372036854775807', (string) $array[1][3]);
+        $this->assertEquals('0', (string) $array[1][4]);
+    }
+
+    public function testDynamicMultiDimensionArrayLongs()
+    {
+        $array = $this->getDynamicField('d_ma_l');
+        $this->assertCount(2, $array);
+        $this->assertCount(6, $array[0]);
+        $this->assertCount(5, $array[1]);
+
+        $this->assertEquals('1234', (string) $array[0][0]);
+        $this->assertEquals('32767', (string) $array[0][1]);
+        $this->assertEquals('32768', (string) $array[0][2]);
+        $this->assertEquals('2147483647', (string) $array[0][3]);
+        $this->assertEquals('-1', (string) $array[0][4]);
+        $this->assertEquals('-1234', (string) $array[0][5]);
+
+        $this->assertEquals('-2147483648', (string) $array[1][0]);
+        $this->assertEquals('-32768', (string) $array[1][1]);
+        $this->assertEquals('-9223372036854775808', (string) $array[1][2]);
+        $this->assertEquals('9223372036854775807', (string) $array[1][3]);
+        $this->assertEquals('0', (string) $array[1][4]);
+    }
+}

--- a/tests/BoundaryValueTypeForShortTest.php
+++ b/tests/BoundaryValueTypeForShortTest.php
@@ -1,0 +1,164 @@
+<?php
+namespace PHPJava\Tests;
+
+class BoundaryValueTypeForShortTest extends Base
+{
+    use Helpers\GetField;
+    use Helpers\AssertionHelpers\AssertFields;
+
+    protected $fixtures = [
+        'BoundaryValueTypeForShortTest',
+    ];
+
+    public function testStaticS0()
+    {
+        $this->assertStaticField(
+            '1234',
+            's0'
+        );
+    }
+
+    public function testStaticS1()
+    {
+        $this->assertStaticField(
+            '32767',
+            's1'
+        );
+    }
+
+    public function testStaticS2()
+    {
+        $this->assertStaticField(
+            '-1',
+            's2'
+        );
+    }
+
+    public function testStaticS3()
+    {
+        $this->assertStaticField(
+            '-1234',
+            's3'
+        );
+    }
+
+    public function testStaticS4()
+    {
+        $this->assertStaticField(
+            '-32768',
+            's4'
+        );
+    }
+
+    public function testStaticS5()
+    {
+        $this->assertStaticField(
+            '0',
+            's5'
+        );
+    }
+
+    public function testDynamicS0()
+    {
+        $this->assertDynamicField(
+            '1234',
+            's0'
+        );
+    }
+
+    public function testDynamicS1()
+    {
+        $this->assertDynamicField(
+            '32767',
+            's1'
+        );
+    }
+
+    public function testDynamicS2()
+    {
+        $this->assertDynamicField(
+            '-1',
+            's2'
+        );
+    }
+
+    public function testDynamicS3()
+    {
+        $this->assertDynamicField(
+            '-1234',
+            's3'
+        );
+    }
+
+    public function testDynamicS4()
+    {
+        $this->assertDynamicField(
+            '-32768',
+            's4'
+        );
+    }
+
+    public function testDynamicS5()
+    {
+        $this->assertDynamicField(
+            '0',
+            's5'
+        );
+    }
+
+    public function testStaticArrayShorts()
+    {
+        $array = $this->getStaticField('s_a_s');
+        $this->assertCount(6, $array);
+
+        $this->assertEquals('1234', (string) $array[0]);
+        $this->assertEquals('32767', (string) $array[1]);
+        $this->assertEquals('-1', (string) $array[2]);
+        $this->assertEquals('-1234', (string) $array[3]);
+        $this->assertEquals('-32768', (string) $array[4]);
+        $this->assertEquals('0', (string) $array[5]);
+    }
+
+    public function testDynamicArrayShorts()
+    {
+        $array = $this->getDynamicField('d_a_s');
+        $this->assertCount(6, $array);
+
+        $this->assertEquals('1234', (string) $array[0]);
+        $this->assertEquals('32767', (string) $array[1]);
+        $this->assertEquals('-1', (string) $array[2]);
+        $this->assertEquals('-1234', (string) $array[3]);
+        $this->assertEquals('-32768', (string) $array[4]);
+        $this->assertEquals('0', (string) $array[5]);
+    }
+
+    public function testStaticMultiDimensionArrayShorts()
+    {
+        $array = $this->getStaticField('s_ma_s');
+        $this->assertCount(2, $array);
+        $this->assertCount(3, $array[0]);
+        $this->assertCount(3, $array[1]);
+
+        $this->assertEquals('1234', (string) $array[0][0]);
+        $this->assertEquals('32767', (string) $array[0][1]);
+        $this->assertEquals('-1', (string) $array[0][2]);
+        $this->assertEquals('-1234', (string) $array[1][0]);
+        $this->assertEquals('-32768', (string) $array[1][1]);
+        $this->assertEquals('0', (string) $array[1][2]);
+    }
+
+    public function testDynamicMultiDimensionArrayShorts()
+    {
+        $array = $this->getDynamicField('d_ma_s');
+        $this->assertCount(2, $array);
+        $this->assertCount(3, $array[0]);
+        $this->assertCount(3, $array[1]);
+
+        $this->assertEquals('1234', (string) $array[0][0]);
+        $this->assertEquals('32767', (string) $array[0][1]);
+        $this->assertEquals('-1', (string) $array[0][2]);
+        $this->assertEquals('-1234', (string) $array[1][0]);
+        $this->assertEquals('-32768', (string) $array[1][1]);
+        $this->assertEquals('0', (string) $array[1][2]);
+    }
+}

--- a/tests/BranchIfTest.php
+++ b/tests/BranchIfTest.php
@@ -11,7 +11,7 @@ class BranchIfTest extends Base
 
     private function call($method, $value1, $value2)
     {
-        $calculatedValue = $this->initiatedJavaClasses['BranchIfTest']
+        $calculatedValue = static::$initiatedJavaClasses['BranchIfTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/BubbleSortTest.php
+++ b/tests/BubbleSortTest.php
@@ -10,7 +10,7 @@ class BubbleSortTest extends Base
     public function testBubbleSortAsc()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['BubbleSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['BubbleSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -25,7 +25,7 @@ class BubbleSortTest extends Base
     public function testBubbleSortDesc()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['BubbleSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['BubbleSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -40,7 +40,7 @@ class BubbleSortTest extends Base
     public function testBubbleSortAscByParam()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['BubbleSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['BubbleSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -58,7 +58,7 @@ class BubbleSortTest extends Base
     public function testBubbleSortDescByParam()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['BubbleSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['BubbleSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/CallToAmbiguousMethodsTest.php
+++ b/tests/CallToAmbiguousMethodsTest.php
@@ -35,7 +35,7 @@ class CallToAmbiguousMethodsTest extends Base
 
     private function call($name, ...$parameters)
     {
-        return $this->initiatedJavaClasses['CallToAmbiguousMethodsTest']
+        return static::$initiatedJavaClasses['CallToAmbiguousMethodsTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -17,7 +17,7 @@ class CastTest extends Base
 
     public function testIntToShort()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -32,7 +32,7 @@ class CastTest extends Base
 
     public function testIntToDouble()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -48,7 +48,7 @@ class CastTest extends Base
 
     public function testIntToFloat()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -65,7 +65,7 @@ class CastTest extends Base
     public function testIntToByte()
     {
         // Byte processing is special.
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -82,7 +82,7 @@ class CastTest extends Base
     public function testIntToChar()
     {
         // Char processing is special.
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -98,7 +98,7 @@ class CastTest extends Base
 
     public function testLongToDouble()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -113,7 +113,7 @@ class CastTest extends Base
 
     public function testLongToFloat()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -129,7 +129,7 @@ class CastTest extends Base
 
     public function testLongToInt()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -145,7 +145,7 @@ class CastTest extends Base
 
     public function testDoubleToFloat()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -160,7 +160,7 @@ class CastTest extends Base
 
     public function testDoubleToInt()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -176,7 +176,7 @@ class CastTest extends Base
 
     public function testDoubleToLong()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -192,7 +192,7 @@ class CastTest extends Base
 
     public function testFloatToDouble()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -207,7 +207,7 @@ class CastTest extends Base
 
     public function testFloatToInt()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -223,7 +223,7 @@ class CastTest extends Base
 
     public function testFloatToLong()
     {
-        $result = $this->initiatedJavaClasses['CastTest']
+        $result = static::$initiatedJavaClasses['CastTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -12,7 +12,7 @@ class ConstructTest extends Base
     public function testConstructorWithParametersPattern1()
     {
         ob_start();
-        $result = $this->initiatedJavaClasses['ConstructorWithParametersTest']
+        $result = static::$initiatedJavaClasses['ConstructorWithParametersTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -27,7 +27,7 @@ class ConstructTest extends Base
     public function testConstructorWithParametersPattern2()
     {
         ob_start();
-        $result = $this->initiatedJavaClasses['ConstructorWithParametersTest']
+        $result = static::$initiatedJavaClasses['ConstructorWithParametersTest']
             ->getInvoker()
             ->construct('Hello World!')
             ->getDynamic()
@@ -40,7 +40,7 @@ class ConstructTest extends Base
     public function testConstructorNoParameterPattern1()
     {
         ob_start();
-        $result = $this->initiatedJavaClasses['ConstructorNoParameterTest']
+        $result = static::$initiatedJavaClasses['ConstructorNoParameterTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -55,7 +55,7 @@ class ConstructTest extends Base
     public function testConstructorNoParameterPattern2()
     {
         ob_start();
-        $result = $this->initiatedJavaClasses['ConstructorNoParameterTest']
+        $result = static::$initiatedJavaClasses['ConstructorNoParameterTest']
             ->getInvoker()
             ->construct()
             ->getDynamic()
@@ -67,7 +67,7 @@ class ConstructTest extends Base
 
     public function testDynamicField()
     {
-        $text = $this->initiatedJavaClasses['ConstructTest']
+        $text = static::$initiatedJavaClasses['ConstructTest']
             ->getInvoker()
             ->construct()
             ->getDynamic()
@@ -76,7 +76,7 @@ class ConstructTest extends Base
 
         $this->assertEquals('Default Text', $text);
 
-        $text = $this->initiatedJavaClasses['ConstructTest']
+        $text = static::$initiatedJavaClasses['ConstructTest']
             ->getInvoker()
             ->getDynamic()
             ->getFields()
@@ -87,7 +87,7 @@ class ConstructTest extends Base
 
         // Re-construction will be changed to default text
 
-        $text = $this->initiatedJavaClasses['ConstructTest']
+        $text = static::$initiatedJavaClasses['ConstructTest']
             ->getInvoker()
             ->construct()
             ->getDynamic()

--- a/tests/DoubleCalculationTest.php
+++ b/tests/DoubleCalculationTest.php
@@ -11,7 +11,7 @@ class DoubleCalculationTest extends Base
 
     private function call($name, ...$parameters)
     {
-        return (string) $this->initiatedJavaClasses['DoubleCalculationTest']
+        return (string) static::$initiatedJavaClasses['DoubleCalculationTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/DoubleOfTypesCompreingTest.php
+++ b/tests/DoubleOfTypesCompreingTest.php
@@ -12,7 +12,7 @@ class DoubleOfTypesComparingTest extends Base
     public function testLessThan()
     {
         ob_start();
-        $this->initiatedJavaClasses['DoubleOfTypesComparingTest']
+        static::$initiatedJavaClasses['DoubleOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -27,7 +27,7 @@ class DoubleOfTypesComparingTest extends Base
     public function testLessThanAndEquals()
     {
         ob_start();
-        $this->initiatedJavaClasses['DoubleOfTypesComparingTest']
+        static::$initiatedJavaClasses['DoubleOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -42,7 +42,7 @@ class DoubleOfTypesComparingTest extends Base
     public function testGraterThan()
     {
         ob_start();
-        $this->initiatedJavaClasses['DoubleOfTypesComparingTest']
+        static::$initiatedJavaClasses['DoubleOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -57,7 +57,7 @@ class DoubleOfTypesComparingTest extends Base
     public function testGraterThanAndEquals()
     {
         ob_start();
-        $this->initiatedJavaClasses['DoubleOfTypesComparingTest']
+        static::$initiatedJavaClasses['DoubleOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/EnclosingMethodTest.php
+++ b/tests/EnclosingMethodTest.php
@@ -10,7 +10,7 @@ class EnclosingMethodTest extends Base
     public function testEnclosingMethod()
     {
         ob_start();
-        $this->initiatedJavaClasses['EnclosingMethodTest']
+        static::$initiatedJavaClasses['EnclosingMethodTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/ExtendingClassTest.php
+++ b/tests/ExtendingClassTest.php
@@ -12,7 +12,7 @@ class ExtendingClassTest extends Base
     public function testExtendingClassPattern1()
     {
         ob_start();
-        $this->initiatedJavaClasses['ExtendingClassTest1']
+        static::$initiatedJavaClasses['ExtendingClassTest1']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -27,7 +27,7 @@ class ExtendingClassTest extends Base
     public function testExtendingClassPattern2()
     {
         ob_start();
-        $this->initiatedJavaClasses['ExtendingClassTest2']
+        static::$initiatedJavaClasses['ExtendingClassTest2']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/FizzBuzzTest.php
+++ b/tests/FizzBuzzTest.php
@@ -11,7 +11,7 @@ class FizzBuzzTest extends Base
     {
         ob_start();
 
-        $calculatedValue = $this->initiatedJavaClasses['FizzBuzzTest']
+        $calculatedValue = static::$initiatedJavaClasses['FizzBuzzTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/FloatCalculationTest.php
+++ b/tests/FloatCalculationTest.php
@@ -11,7 +11,7 @@ class FloatCalculationTest extends Base
 
     private function call($name, ...$parameters)
     {
-        return (string) $this->initiatedJavaClasses['FloatCalculationTest']
+        return (string) static::$initiatedJavaClasses['FloatCalculationTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/FloatOfTypesCompreingTest.php
+++ b/tests/FloatOfTypesCompreingTest.php
@@ -12,7 +12,7 @@ class FloatOfTypesComparingTest extends Base
     public function testLessThan()
     {
         ob_start();
-        $this->initiatedJavaClasses['FloatOfTypesComparingTest']
+        static::$initiatedJavaClasses['FloatOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -27,7 +27,7 @@ class FloatOfTypesComparingTest extends Base
     public function testLessThanAndEquals()
     {
         ob_start();
-        $this->initiatedJavaClasses['FloatOfTypesComparingTest']
+        static::$initiatedJavaClasses['FloatOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -42,7 +42,7 @@ class FloatOfTypesComparingTest extends Base
     public function testGraterThan()
     {
         ob_start();
-        $this->initiatedJavaClasses['FloatOfTypesComparingTest']
+        static::$initiatedJavaClasses['FloatOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -57,7 +57,7 @@ class FloatOfTypesComparingTest extends Base
     public function testGraterThanAndEquals()
     {
         ob_start();
-        $this->initiatedJavaClasses['FloatOfTypesComparingTest']
+        static::$initiatedJavaClasses['FloatOfTypesComparingTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/GetFieldTest.php
+++ b/tests/GetFieldTest.php
@@ -9,7 +9,7 @@ class GetFieldTest extends Base
 
     public function testGetField()
     {
-        $actual = $this->initiatedJavaClasses['GetFieldTest']
+        $actual = static::$initiatedJavaClasses['GetFieldTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/Helpers/AssertionHelpers/AssertFields.php
+++ b/tests/Helpers/AssertionHelpers/AssertFields.php
@@ -1,0 +1,36 @@
+<?php
+namespace PHPJava\Tests\Helpers\AssertionHelpers;
+
+trait AssertFields
+{
+    /**
+     * @param $expected
+     * @param $number
+     */
+    private function assertStaticField($expected, $number)
+    {
+        $result = static::$initiatedJavaClasses[$this->fixtures[0]]
+            ->getInvoker()
+            ->getStatic()
+            ->getFields()
+            ->get("s_{$number}");
+
+        $this->assertEquals($expected, (string) $result);
+    }
+
+    private function assertDynamicField($expected, $number)
+    {
+        static $instance = null;
+        if ($instance === null) {
+            $instance = static::$initiatedJavaClasses[$this->fixtures[0]]
+                ->getInvoker()
+                ->construct();
+        }
+        $result = $instance
+            ->getDynamic()
+            ->getFields()
+            ->get("d_{$number}");
+
+        $this->assertEquals($expected, (string) $result);
+    }
+}

--- a/tests/Helpers/GetField.php
+++ b/tests/Helpers/GetField.php
@@ -1,0 +1,28 @@
+<?php
+namespace PHPJava\Tests\Helpers;
+
+trait GetField
+{
+    private function getStaticField($name)
+    {
+        return static::$initiatedJavaClasses[$this->fixtures[0]]
+            ->getInvoker()
+            ->getStatic()
+            ->getFields()
+            ->get($name);
+    }
+
+    private function getDynamicField($name)
+    {
+        static $instance = null;
+        if ($instance === null) {
+            $instance = static::$initiatedJavaClasses[$this->fixtures[0]]
+                ->getInvoker()
+                ->construct();
+        }
+        return $instance
+            ->getDynamic()
+            ->getFields()
+            ->get($name);
+    }
+}

--- a/tests/Helpers/MakeUnicodeChar.php
+++ b/tests/Helpers/MakeUnicodeChar.php
@@ -1,0 +1,10 @@
+<?php
+namespace PHPJava\Tests\Helpers;
+
+trait MakeUnicodeChar
+{
+    private function makeUnicodeChar($codePoint)
+    {
+        return json_decode(sprintf('"\u%04X"', $codePoint));
+    }
+}

--- a/tests/InnerClassTest.php
+++ b/tests/InnerClassTest.php
@@ -11,7 +11,7 @@ class InnerClassTest extends Base
     {
         ob_start();
         // call main
-        $this->initiatedJavaClasses['InnerClassTest']
+        static::$initiatedJavaClasses['InnerClassTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/InsertionSortTest.php
+++ b/tests/InsertionSortTest.php
@@ -10,7 +10,7 @@ class InsertionSortTest extends Base
     public function testInsertionSortAsc()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['InsertionSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['InsertionSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -25,7 +25,7 @@ class InsertionSortTest extends Base
     public function testInsertionSortDesc()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['InsertionSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['InsertionSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -40,7 +40,7 @@ class InsertionSortTest extends Base
     public function testInsertionSortAscByParam()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['InsertionSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['InsertionSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -58,7 +58,7 @@ class InsertionSortTest extends Base
     public function testInsertionSortDescByParam()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['InsertionSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['InsertionSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/InstanceOfTest.php
+++ b/tests/InstanceOfTest.php
@@ -9,7 +9,7 @@ class InstanceOfTest extends Base
 
     private function call($method)
     {
-        return $this->initiatedJavaClasses['InstanceOfTest']
+        return static::$initiatedJavaClasses['InstanceOfTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/IntConstTest.php
+++ b/tests/IntConstTest.php
@@ -9,7 +9,7 @@ class IntConstTest extends Base
 
     private function call($method)
     {
-        $calculatedValue = $this->initiatedJavaClasses['IntConstTest']
+        $calculatedValue = static::$initiatedJavaClasses['IntConstTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/IntegerCalculationTest.php
+++ b/tests/IntegerCalculationTest.php
@@ -9,7 +9,7 @@ class IntegerCalculationTest extends Base
 
     private function call($name, ...$parameters)
     {
-        return $this->initiatedJavaClasses['IntegerCalculationTest']
+        return static::$initiatedJavaClasses['IntegerCalculationTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/InvokeOperationsTest.php
+++ b/tests/InvokeOperationsTest.php
@@ -10,7 +10,7 @@ class InvokeOperationsTest extends Base
     public function testInvokeInterface()
     {
         ob_start();
-        $this->initiatedJavaClasses['InvokeDynamicTest']
+        static::$initiatedJavaClasses['InvokeDynamicTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/LongCalculationTest.php
+++ b/tests/LongCalculationTest.php
@@ -11,7 +11,7 @@ class LongCalculationTest extends Base
 
     private function call($name, ...$parameters)
     {
-        return $this->initiatedJavaClasses['LongCalculationTest']
+        return static::$initiatedJavaClasses['LongCalculationTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/LoopTest.php
+++ b/tests/LoopTest.php
@@ -9,7 +9,7 @@ class LoopTest extends Base
 
     public function testCallCalculateByFor()
     {
-        $calculatedValue = $this->initiatedJavaClasses['LoopTest']
+        $calculatedValue = static::$initiatedJavaClasses['LoopTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -19,7 +19,7 @@ class LoopTest extends Base
             (string) $calculatedValue
         );
 
-        $calculatedValue = $this->initiatedJavaClasses['LoopTest']
+        $calculatedValue = static::$initiatedJavaClasses['LoopTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -32,7 +32,7 @@ class LoopTest extends Base
 
     public function testCallCalculateByWhile()
     {
-        $calculatedValue = $this->initiatedJavaClasses['LoopTest']
+        $calculatedValue = static::$initiatedJavaClasses['LoopTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -42,7 +42,7 @@ class LoopTest extends Base
             (string) $calculatedValue
         );
 
-        $calculatedValue = $this->initiatedJavaClasses['LoopTest']
+        $calculatedValue = static::$initiatedJavaClasses['LoopTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/MethodParameterTest.php
+++ b/tests/MethodParameterTest.php
@@ -13,7 +13,7 @@ class MethodParameterTest extends Base
     {
         $e = null;
         try {
-            $value = $this->initiatedJavaClasses['MethodParameterTest']
+            $value = static::$initiatedJavaClasses['MethodParameterTest']
                 ->getInvoker()
                 ->getStatic()
                 ->getMethods()
@@ -33,7 +33,7 @@ class MethodParameterTest extends Base
     public function testMethodParameterIsEmpty()
     {
         ob_start();
-        $value = $this->initiatedJavaClasses['MethodParameterTest']
+        $value = static::$initiatedJavaClasses['MethodParameterTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -49,7 +49,7 @@ class MethodParameterTest extends Base
     {
         $e = null;
         try {
-            $value = $this->initiatedJavaClasses['MethodParameterTest']
+            $value = static::$initiatedJavaClasses['MethodParameterTest']
                 ->getInvoker()
                 ->getStatic()
                 ->getMethods()

--- a/tests/NegationTest.php
+++ b/tests/NegationTest.php
@@ -14,7 +14,7 @@ class NegationTest extends Base
 
     private function call($method, ...$arguments)
     {
-        $calculatedValue = $this->initiatedJavaClasses['NegationTest']
+        $calculatedValue = static::$initiatedJavaClasses['NegationTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/ObjectCompareTest.php
+++ b/tests/ObjectCompareTest.php
@@ -10,7 +10,7 @@ class ObjectCompareTest extends Base
     public function testObjectCompareTest()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['ObjectCompareTest']
+        $calculatedValue = static::$initiatedJavaClasses['ObjectCompareTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/OuterClassTest.php
+++ b/tests/OuterClassTest.php
@@ -11,7 +11,7 @@ class OuterClassTest extends Base
     public function testCallMain()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['OuterClassTest']
+        $calculatedValue = static::$initiatedJavaClasses['OuterClassTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/OutputDebugTraceTest.php
+++ b/tests/OutputDebugTraceTest.php
@@ -19,7 +19,7 @@ class OutputDebugTraceTest extends Base
             ],
         ]);
 
-        $calculatedValue = $this->initiatedJavaClasses['OutputDebugTraceTest']
+        $calculatedValue = static::$initiatedJavaClasses['OutputDebugTraceTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -30,7 +30,7 @@ class OutputDebugTraceTest extends Base
         ob_end_clean();
 
         ob_start();
-        $this->initiatedJavaClasses['OutputDebugTraceTest']->debug();
+        static::$initiatedJavaClasses['OutputDebugTraceTest']->debug();
         $result = ob_get_clean();
         $this->assertEquals(
             file_get_contents(__DIR__ . '/templates/DebugTraceTest.txt'),

--- a/tests/Packages/JavaIoPrintStreamClassTest.php
+++ b/tests/Packages/JavaIoPrintStreamClassTest.php
@@ -12,7 +12,7 @@ class JavaIoPrintStreamClassTest extends Base
     private function call($method, ...$arguments)
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaIoPrintStreamClassTest']
+        static::$initiatedJavaClasses['JavaIoPrintStreamClassTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/Packages/JavaLangMathTest.php
+++ b/tests/Packages/JavaLangMathTest.php
@@ -12,7 +12,7 @@ class JavaLangMathTest extends Base
     public function testAbs()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -27,7 +27,7 @@ class JavaLangMathTest extends Base
     public function testAcos()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -42,7 +42,7 @@ class JavaLangMathTest extends Base
     public function testAddExact()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -58,7 +58,7 @@ class JavaLangMathTest extends Base
     public function testAsin()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -73,7 +73,7 @@ class JavaLangMathTest extends Base
     public function testAtan()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -88,7 +88,7 @@ class JavaLangMathTest extends Base
     public function testAtan2()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -104,7 +104,7 @@ class JavaLangMathTest extends Base
     public function testCbrt()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -119,7 +119,7 @@ class JavaLangMathTest extends Base
     public function testCeil()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -134,7 +134,7 @@ class JavaLangMathTest extends Base
     public function testCopySign()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -150,7 +150,7 @@ class JavaLangMathTest extends Base
     public function testCos()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -165,7 +165,7 @@ class JavaLangMathTest extends Base
     public function testCosh()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -180,7 +180,7 @@ class JavaLangMathTest extends Base
     public function testDecrementExact()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -195,7 +195,7 @@ class JavaLangMathTest extends Base
     public function testExp()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -210,7 +210,7 @@ class JavaLangMathTest extends Base
     public function testExpm1()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -225,7 +225,7 @@ class JavaLangMathTest extends Base
     public function testFloor()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -241,7 +241,7 @@ class JavaLangMathTest extends Base
     // public function testFloorDiv()
     // {
     //     ob_start();
-    //     $this->initiatedJavaClasses['JavaLangMathTest']
+    //     static::$initiatedJavaClasses['JavaLangMathTest']
     //         ->getInvoker()
     //         ->getStatic()
     //         ->getMethods()
@@ -258,7 +258,7 @@ class JavaLangMathTest extends Base
     // public function testFloorMod()
     // {
     //     ob_start();
-    //     $this->initiatedJavaClasses['JavaLangMathTest']
+    //     static::$initiatedJavaClasses['JavaLangMathTest']
     //         ->getInvoker()
     //         ->getStatic()
     //         ->getMethods()
@@ -274,7 +274,7 @@ class JavaLangMathTest extends Base
     public function testIncrementExact()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -289,7 +289,7 @@ class JavaLangMathTest extends Base
     public function testLog()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -304,7 +304,7 @@ class JavaLangMathTest extends Base
     public function testLog10()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -319,7 +319,7 @@ class JavaLangMathTest extends Base
     public function testLog1p()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -334,7 +334,7 @@ class JavaLangMathTest extends Base
     public function testMax()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -350,7 +350,7 @@ class JavaLangMathTest extends Base
     public function testMin()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -367,7 +367,7 @@ class JavaLangMathTest extends Base
     // public function testMultiplyExact()
     // {
     //     ob_start();
-    //     $this->initiatedJavaClasses['JavaLangMathTest']
+    //     static::$initiatedJavaClasses['JavaLangMathTest']
     //         ->getInvoker()
     //         ->getStatic()
     //         ->getMethods()
@@ -384,7 +384,7 @@ class JavaLangMathTest extends Base
     // public function testMultiplyFull()
     // {
     //     ob_start();
-    //     $this->initiatedJavaClasses['JavaLangMathTest']
+    //     static::$initiatedJavaClasses['JavaLangMathTest']
     //         ->getInvoker()
     //         ->getStatic()
     //         ->getMethods()
@@ -400,7 +400,7 @@ class JavaLangMathTest extends Base
     public function testPow()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -418,7 +418,7 @@ class JavaLangMathTest extends Base
         mt_srand(1234);
 
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -432,7 +432,7 @@ class JavaLangMathTest extends Base
     public function testRound()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -447,7 +447,7 @@ class JavaLangMathTest extends Base
     public function testSin()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -462,7 +462,7 @@ class JavaLangMathTest extends Base
     public function testSinh()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -477,7 +477,7 @@ class JavaLangMathTest extends Base
     public function testSqrt()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -492,7 +492,7 @@ class JavaLangMathTest extends Base
     public function testSubtractExact()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -508,7 +508,7 @@ class JavaLangMathTest extends Base
     public function testTan()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -523,7 +523,7 @@ class JavaLangMathTest extends Base
     public function testTanh()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangMathTest']
+        static::$initiatedJavaClasses['JavaLangMathTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/Packages/JavaLangStringTest.php
+++ b/tests/Packages/JavaLangStringTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace PHPJava\Tests\Packages;
 
+use PHPJava\Core\JavaClass;
 use PHPJava\Exceptions\UncaughtException;
 use PHPJava\Packages\java\lang\IndexOutOfBoundsException;
 use PHPJava\Tests\Base;
@@ -14,7 +15,7 @@ class JavaLangStringTest extends Base
     public function testCharAtIndex()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -33,7 +34,7 @@ class JavaLangStringTest extends Base
         $this->expectExceptionMessage('String index out of range: -1');
 
         try {
-            $this->initiatedJavaClasses['JavaLangStringTest']
+            static::$initiatedJavaClasses['JavaLangStringTest']
                 ->getInvoker()
                 ->getStatic()
                 ->getMethods()
@@ -53,7 +54,7 @@ class JavaLangStringTest extends Base
         $this->expectExceptionMessage('String index out of range: 3');
 
         try {
-            $this->initiatedJavaClasses['JavaLangStringTest']
+            static::$initiatedJavaClasses['JavaLangStringTest']
                 ->getInvoker()
                 ->getStatic()
                 ->getMethods()
@@ -70,7 +71,7 @@ class JavaLangStringTest extends Base
     public function testConcat()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -86,7 +87,7 @@ class JavaLangStringTest extends Base
     public function testHashCode()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -104,7 +105,7 @@ class JavaLangStringTest extends Base
     public function testIntern()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -122,7 +123,7 @@ class JavaLangStringTest extends Base
     public function testNotInterned()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -139,8 +140,11 @@ class JavaLangStringTest extends Base
 
     public function testNotInternedAfterLiteral()
     {
+        // This test need dynamic loading.
+        static::$initiatedJavaClasses['JavaLangStringTest'] = JavaClass::load('JavaLangStringTest');
+
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -161,7 +165,7 @@ class JavaLangStringTest extends Base
     public function testReplace()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -178,7 +182,7 @@ class JavaLangStringTest extends Base
     public function testToLowerCase()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -193,7 +197,7 @@ class JavaLangStringTest extends Base
     public function testToUpperCase()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangStringTest']
+        static::$initiatedJavaClasses['JavaLangStringTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/Packages/JavaLangSystemTest.php
+++ b/tests/Packages/JavaLangSystemTest.php
@@ -12,7 +12,7 @@ class JavaLangSystemTest extends Base
     public function testIdentityHashCode()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaLangSystemTest']
+        static::$initiatedJavaClasses['JavaLangSystemTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/Packages/JavaUtilObjectsTest.php
+++ b/tests/Packages/JavaUtilObjectsTest.php
@@ -12,7 +12,7 @@ class JavaUtilObjectsTest extends Base
     public function testHashCode()
     {
         ob_start();
-        $this->initiatedJavaClasses['JavaUtilObjectsTest']
+        static::$initiatedJavaClasses['JavaUtilObjectsTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/QuickSortTest.php
+++ b/tests/QuickSortTest.php
@@ -10,7 +10,7 @@ class QuickSortTest extends Base
     public function testQuickSortAsc()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['QuickSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['QuickSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -28,7 +28,7 @@ class QuickSortTest extends Base
     public function testQuickSortDesc()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['QuickSortTest']
+        $calculatedValue = static::$initiatedJavaClasses['QuickSortTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/SwitchTest.php
+++ b/tests/SwitchTest.php
@@ -10,7 +10,7 @@ class SwitchTest extends Base
     public function testCallTableswitchPattern1()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['SwitchTest']
+        $calculatedValue = static::$initiatedJavaClasses['SwitchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -29,7 +29,7 @@ class SwitchTest extends Base
     public function testTableswitchPattern2()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['SwitchTest']
+        $calculatedValue = static::$initiatedJavaClasses['SwitchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -48,7 +48,7 @@ class SwitchTest extends Base
     public function testTableswitchPattern3()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['SwitchTest']
+        $calculatedValue = static::$initiatedJavaClasses['SwitchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -67,7 +67,7 @@ class SwitchTest extends Base
     public function testCallLookupswitchPattern1()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['SwitchTest']
+        $calculatedValue = static::$initiatedJavaClasses['SwitchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -86,7 +86,7 @@ class SwitchTest extends Base
     public function testCallLookupswitchPattern2()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['SwitchTest']
+        $calculatedValue = static::$initiatedJavaClasses['SwitchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -105,7 +105,7 @@ class SwitchTest extends Base
     public function testCallLookupswitchPattern3()
     {
         ob_start();
-        $calculatedValue = $this->initiatedJavaClasses['SwitchTest']
+        $calculatedValue = static::$initiatedJavaClasses['SwitchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()

--- a/tests/TryCatchTest.php
+++ b/tests/TryCatchTest.php
@@ -12,7 +12,7 @@ class TryCatchTest extends Base
 
     public function testPassthroughTryStatement()
     {
-        $result = $this->initiatedJavaClasses['TryCatchTest']
+        $result = static::$initiatedJavaClasses['TryCatchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -26,7 +26,7 @@ class TryCatchTest extends Base
 
     public function testPassthroughCatchStatement()
     {
-        $result = $this->initiatedJavaClasses['TryCatchTest']
+        $result = static::$initiatedJavaClasses['TryCatchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -40,7 +40,7 @@ class TryCatchTest extends Base
 
     public function testImitationThrowException()
     {
-        $result = $this->initiatedJavaClasses['TryCatchTest']
+        $result = static::$initiatedJavaClasses['TryCatchTest']
             ->getInvoker()
             ->getStatic()
             ->getMethods()
@@ -58,7 +58,7 @@ class TryCatchTest extends Base
         $this->expectExceptionMessage('String index out of range: -1');
 
         try {
-            $result = $this->initiatedJavaClasses['TryCatchTest']
+            $result = static::$initiatedJavaClasses['TryCatchTest']
                 ->getInvoker()
                 ->getStatic()
                 ->getMethods()

--- a/tests/fixtures/java/BoundaryValueTypeForBooleanTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForBooleanTest.java
@@ -1,0 +1,36 @@
+class BoundaryValueTypeForBooleanTest
+{
+    // boundary value tests for Boolean
+    public static boolean s_b0 = true;
+    public static boolean s_b1 = false;
+    public boolean d_b0 = true;
+    public boolean d_b1 = false;
+    public static boolean[] s_a_b = {
+        true,
+        false,
+    };
+    public boolean[] d_a_b = {
+        true,
+        false,
+    };
+    public static boolean[][] s_ma_b = {
+        {
+            true,
+            false,
+        },
+        {
+            false,
+            true,
+        },
+    };
+    public boolean[][] d_ma_b = {
+        {
+            true,
+            false,
+        },
+        {
+            false,
+            true,
+        },
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForByteTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForByteTest.java
@@ -1,0 +1,62 @@
+class BoundaryValueTypeForByteTest
+{
+    // boundary value tests for Byte
+    public static byte s_by0 = 0x00;
+    public static byte s_by1 = 0x7F;
+    public static byte s_by2 = 0x12;
+    public static byte s_by3 = -0x01;
+    public static byte s_by4 = -0x7F;
+    public static byte s_by5 = -0x12;
+    public static byte s_by6 = -0x80;
+    public byte d_by0 = 0x00;
+    public byte d_by1 = 0x7F;
+    public byte d_by2 = 0x12;
+    public byte d_by3 = -0x01;
+    public byte d_by4 = -0x7F;
+    public byte d_by5 = -0x12;
+    public byte d_by6 = -0x80;
+    public static byte[] s_a_by = {
+        0x00,
+        0x7F,
+        0x12,
+        -0x01,
+        -0x7F,
+        -0x12,
+        -0x80,
+    };
+    public byte[] d_a_by = {
+        0x00,
+        0x7F,
+        0x12,
+        -0x01,
+        -0x7F,
+        -0x12,
+        -0x80,
+    };
+    public static byte[][] s_ma_by = {
+        {
+            0x00,
+            0x7F,
+            0x12,
+        },
+        {
+            -0x01,
+            -0x7F,
+            -0x12,
+            -0x80,
+        },
+    };
+    public byte[][] d_ma_by = {
+        {
+            0x00,
+            0x7F,
+            0x12,
+        },
+        {
+            -0x01,
+            -0x7F,
+            -0x12,
+            -0x80,
+        },
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForCharTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForCharTest.java
@@ -1,0 +1,50 @@
+class BoundaryValueTypeForCharTest
+{
+    // boundary value tests for Char
+    public static char s_c0 = '\u0000';
+    public static char s_c1 = '\uFFFF';
+    public static char s_c2 = '\u7FFF';
+    public static char s_c3 = '\u8000';
+    public static char s_c4 = '\u9123';
+    public char d_c0 = '\u0000';
+    public char d_c1 = '\uFFFF';
+    public char d_c2 = '\u7FFF';
+    public char d_c3 = '\u8000';
+    public char d_c4 = '\u9123';
+    public static char[] s_a_c = {
+        '\u0000',
+        '\uFFFF',
+        '\u7FFF',
+        '\u8000',
+        '\u9123',
+    };
+    public char[] d_a_c = {
+        '\u0000',
+        '\uFFFF',
+        '\u7FFF',
+        '\u8000',
+        '\u9123',
+    };
+    public static char[][] s_ma_c = {
+        {
+            '\u0000',
+            '\uFFFF',
+            '\u7FFF',
+        },
+        {
+            '\u8000',
+            '\u9123',
+        },
+    };
+    public char[][] d_ma_c = {
+        {
+            '\u0000',
+            '\uFFFF',
+            '\u7FFF',
+        },
+        {
+            '\u8000',
+            '\u9123',
+        },
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForDoubleTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForDoubleTest.java
@@ -1,0 +1,287 @@
+class BoundaryValueTypeForDoubleTest
+{
+    // boundary value tests for loats
+    public static double s_d0 = 0;
+    public static double s_d1 = 1234;
+    public static double s_d2 = 0.1234;
+    public static double s_d3 = 1234.0;
+    public static double s_d4 = 1234.1234;
+    public static double s_d5 = -1234;
+    public static double s_d6 = -0.1234;
+    public static double s_d7 = -1234.0;
+    public static double s_d8 = -1234.1234;
+    public static double s_d9 = 0x7f7fffff;
+    public static double s_d10 = -0x7f7fffff;
+    public static double s_d11 = 0xff7fffff;
+    public static double s_d12 = -0xff7fffff;
+    public static double s_d13 = 0xffefffffffffffffL;
+    public static double s_d14 = -0xffefffffffffffffL;
+    public static double s_d15 = 0x7fefffffffffffffL;
+    public static double s_d16 = -0x7fefffffffffffffL;
+    public double d_d0 = 0;
+    public double d_d1 = 1234;
+    public double d_d2 = 0.1234;
+    public double d_d3 = 1234.0;
+    public double d_d4 = 1234.1234;
+    public double d_d5 = -1234;
+    public double d_d6 = -0.1234;
+    public double d_d7 = -1234.0;
+    public double d_d8 = -1234.1234;
+    public double d_d9 = 0x7f7fffff;
+    public double d_d10 = -0x7f7fffff;
+    public double d_d11 = 0xff7fffff;
+    public double d_d12 = -0xff7fffff;
+    public double d_d13 = 0xffefffffffffffffL;
+    public double d_d14 = -0xffefffffffffffffL;
+    public double d_d15 = 0x7fefffffffffffffL;
+    public double d_d16 = -0x7fefffffffffffffL;
+    public static double[] s_a_d = {
+        0,
+        1234,
+        0.1234,
+        1234.0,
+        1234.1234,
+        -1234,
+        -0.1234,
+        -1234.0,
+        -1234.1234,
+        0x7f7fffff,
+        -0x7f7fffff,
+        0xff7fffff,
+        -0xff7fffff,
+        0xffefffffffffffffL,
+        -0xffefffffffffffffL,
+        0x7fefffffffffffffL,
+        -0x7fefffffffffffffL,
+    };
+    public double[] d_a_d = {
+        0,
+        1234,
+        0.1234,
+        1234.0,
+        1234.1234,
+        -1234,
+        -0.1234,
+        -1234.0,
+        -1234.1234,
+        0x7f7fffff,
+        -0x7f7fffff,
+        0xff7fffff,
+        -0xff7fffff,
+        0xffefffffffffffffL,
+        -0xffefffffffffffffL,
+        0x7fefffffffffffffL,
+        -0x7fefffffffffffffL,
+    };
+    public static double[][] s_ma_d = {
+        {
+            0,
+            1234,
+            0.1234,
+            1234.0,
+            1234.1234,
+            -1234,
+            0xffefffffffffffffL,
+            -0xffefffffffffffffL,
+        },
+        {
+            -0.1234,
+            -1234.0,
+            -1234.1234,
+            0x7f7fffff,
+            -0x7f7fffff,
+            0xff7fffff,
+            -0xff7fffff,
+            0x7fefffffffffffffL,
+            -0x7fefffffffffffffL,
+        },
+    };
+    public double[][] d_ma_d = {
+        {
+            0,
+            1234,
+            0.1234,
+            1234.0,
+            1234.1234,
+            -1234,
+            0xffefffffffffffffL,
+            -0xffefffffffffffffL,
+        },
+        {
+            -0.1234,
+            -1234.0,
+            -1234.1234,
+            0x7f7fffff,
+            -0x7f7fffff,
+            0xff7fffff,
+            -0xff7fffff,
+            0x7fefffffffffffffL,
+            -0x7fefffffffffffffL,
+        },
+    };
+
+    // NaN values
+    public static double s_nd0 = 0x7f800001;
+    public static double s_nd1 = 0x7f8ffff1;
+    public static double s_nd2 = 0xff800001;
+    public static double s_nd3 = 0xff8ffff1;
+    public static double s_nd4 = 0xffffffff;
+    public static double s_nd5 = 0x7ff0000000000001L;
+    public static double s_nd6 = 0x7ffffffffffffff1L;
+    public static double s_nd7 = 0x7fffffffffffffffL;
+    public static double s_nd8 = 0xfff0000000000001L;
+    public static double s_nd9 = 0xfffffffffffffff1L;
+    public static double s_nd10 = 0xffffffffffffffffL;
+
+    public double d_nd0 = 0x7f800001;
+    public double d_nd1 = 0x7f8ffff1;
+    public double d_nd2 = 0xff800001;
+    public double d_nd3 = 0xff8ffff1;
+    public double d_nd4 = 0xffffffff;
+    public double d_nd5 = 0x7ff0000000000001L;
+    public double d_nd6 = 0x7ffffffffffffff1L;
+    public double d_nd7 = 0x7fffffffffffffffL;
+    public double d_nd8 = 0xfff0000000000001L;
+    public double d_nd9 = 0xfffffffffffffff1L;
+    public double d_nd10 = 0xffffffffffffffffL;
+
+    public static double[] s_a_nd = {
+        0x7f800001,
+        0x7f8ffff1,
+        0xff800001,
+        0xff8ffff1,
+        0xffffffff,
+        0x7ff0000000000001L,
+        0x7ffffffffffffff1L,
+        0x7fffffffffffffffL,
+        0xfff0000000000001L,
+        0xfffffffffffffff1L,
+        0xffffffffffffffffL,
+    };
+    public double[] d_a_nd = {
+        0x7f800001,
+        0x7f8ffff1,
+        0xff800001,
+        0xff8ffff1,
+        0xffffffff,
+        0x7ff0000000000001L,
+        0x7ffffffffffffff1L,
+        0x7fffffffffffffffL,
+        0xfff0000000000001L,
+        0xfffffffffffffff1L,
+        0xffffffffffffffffL,
+    };
+    public static double[][] s_ma_nd = {
+        {
+            0x7f800001,
+            0x7f8ffff1,
+            0xff800001,
+            0x7ff0000000000001L,
+            0x7ffffffffffffff1L,
+            0x7fffffffffffffffL,
+        },
+        {
+            0xff8ffff1,
+            0xffffffff,
+            0xfff0000000000001L,
+            0xfffffffffffffff1L,
+            0xffffffffffffffffL,
+        },
+    };
+    public double[][] d_ma_nd = {
+        {
+            0x7f800001,
+            0x7f8ffff1,
+            0xff800001,
+            0x7ff0000000000001L,
+            0x7ffffffffffffff1L,
+            0x7fffffffffffffffL,
+        },
+        {
+            0xff8ffff1,
+            0xffffffff,
+            0xfff0000000000001L,
+            0xfffffffffffffff1L,
+            0xffffffffffffffffL,
+        },
+    };
+
+
+    // Indinity values (Positive)
+    public static double s_ipd0 = 0x7f800000;
+    public static double s_ipd1 = 0x7ff0000000000000L;
+    public double d_ipd0 = 0x7f800000;
+    public double d_ipd1 = 0x7ff0000000000000L;
+    public static double[] s_a_ipd = {
+        0x7f800000,
+        0x7f800000,
+        0x7ff0000000000000L,
+        0x7ff0000000000000L,
+    };
+    public double[] d_a_ipd = {
+        0x7f800000,
+        0x7f800000,
+        0x7ff0000000000000L,
+        0x7ff0000000000000L,
+    };
+    public static double[][] s_ma_ipd = {
+        {
+            0x7f800000,
+            0x7ff0000000000000L,
+        },
+        {
+            0x7f800000,
+            0x7ff0000000000000L,
+        },
+    };
+    public double[][] d_ma_ipd = {
+        {
+            0x7f800000,
+            0x7ff0000000000000L,
+        },
+        {
+            0x7f800000,
+            0x7ff0000000000000L,
+        },
+    };
+
+    // Infinity values (Negative)
+    public static double s_ind0 = 0xff800000;
+    public static double s_ind1 = 0xfff0000000000000L;
+    public double d_ind0 = 0xff800000;
+    public double d_ind1 = 0xfff0000000000000L;
+    public static double[] s_a_ind = {
+        0x7f800000,
+        0xff800000,
+        0xfff0000000000000L,
+    };
+    public double[] d_a_ind = {
+        0x7f800000,
+        0xff800000,
+        0xfff0000000000000L,
+    };
+    public static double[][] s_ma_ind = {
+        {
+            0x7f800000,
+            0xff800000,
+            0xfff0000000000000L,
+        },
+        {
+            0x7f800000,
+            0xff800000,
+            0xfff0000000000000L,
+        }
+    };
+    public double[][] d_ma_ind = {
+        {
+            0x7f800000,
+            0xff800000,
+            0xfff0000000000000L,
+        },
+        {
+            0x7f800000,
+            0xff800000,
+            0xfff0000000000000L,
+        }
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForFloatTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForFloatTest.java
@@ -1,0 +1,207 @@
+class BoundaryValueTypeForFloatTest
+{
+    // boundary value tests for Floats
+    public static float s_f0 = 0;
+    public static float s_f1 = 1234F;
+    public static float s_f2 = 0.1234F;
+    public static float s_f3 = 1234.0F;
+    public static float s_f4 = 1234.1234F;
+    public static float s_f5 = -1234F;
+    public static float s_f6 = -0.1234F;
+    public static float s_f7 = -1234.0F;
+    public static float s_f8 = -1234.1234F;
+    public static float s_f9 = 0x7f7fffff;
+    public static float s_f10 = -0x7f7fffff;
+    public static float s_f11 = 0xff7fffff;
+    public static float s_f12 = -0xff7fffff;
+    public float d_f0 = 0;
+    public float d_f1 = 1234F;
+    public float d_f2 = 0.1234F;
+    public float d_f3 = 1234.0F;
+    public float d_f4 = 1234.1234F;
+    public float d_f5 = -1234F;
+    public float d_f6 = -0.1234F;
+    public float d_f7 = -1234.0F;
+    public float d_f8 = -1234.1234F;
+    public float d_f9 = 0x7f7fffff;
+    public float d_f10 = -0x7f7fffff;
+    public float d_f11 = 0xff7fffff;
+    public float d_f12 = -0xff7fffff;
+    public static float[] s_a_f = {
+        0,
+        1234F,
+        0.1234F,
+        1234.0F,
+        1234.1234F,
+        -1234F,
+        -0.1234F,
+        -1234.0F,
+        -1234.1234F,
+        0x7f7fffff,
+        -0x7f7fffff,
+        0xff7fffff,
+        -0xff7fffff,
+    };
+    public float[] d_a_f = {
+        0,
+        1234F,
+        0.1234F,
+        1234.0F,
+        1234.1234F,
+        -1234F,
+        -0.1234F,
+        -1234.0F,
+        -1234.1234F,
+        0x7f7fffff,
+        -0x7f7fffff,
+        0xff7fffff,
+        -0xff7fffff,
+    };
+    public static float[][] s_ma_f = {
+        {
+            0,
+            1234F,
+            0.1234F,
+            1234.0F,
+            1234.1234F,
+            -1234F,
+        },
+        {
+            -0.1234F,
+            -1234.0F,
+            -1234.1234F,
+            0x7f7fffff,
+            -0x7f7fffff,
+            0xff7fffff,
+            -0xff7fffff,
+        },
+    };
+    public float[][] d_ma_f = {
+        {
+            0,
+            1234F,
+            0.1234F,
+            1234.0F,
+            1234.1234F,
+            -1234F,
+        },
+        {
+            -0.1234F,
+            -1234.0F,
+            -1234.1234F,
+            0x7f7fffff,
+            -0x7f7fffff,
+            0xff7fffff,
+            -0xff7fffff,
+        },
+    };
+
+    // NaN values
+    public static float s_nf0 = 0x7f800001;
+    public static float s_nf1 = 0x7f8ffff1;
+    public static float s_nf2 = 0xff800001;
+    public static float s_nf3 = 0xff8ffff1;
+    public static float s_nf4 = 0xffffffff;
+    public float d_nf0 = 0x7f800001;
+    public float d_nf1 = 0x7f8ffff1;
+    public float d_nf2 = 0xff800001;
+    public float d_nf3 = 0xff8ffff1;
+    public float d_nf4 = 0xffffffff;
+    public static float[] s_a_nf = {
+        0x7f800001,
+        0x7f8ffff1,
+        0xff800001,
+        0xff8ffff1,
+        0xffffffff,
+    };
+    public float[] d_a_nf = {
+        0x7f800001,
+        0x7f8ffff1,
+        0xff800001,
+        0xff8ffff1,
+        0xffffffff,
+    };
+    public static float[][] s_ma_nf = {
+        {
+            0x7f800001,
+            0x7f8ffff1,
+            0xff800001,
+        },
+        {
+            0xff8ffff1,
+            0xffffffff,
+        },
+    };
+    public float[][] d_ma_nf = {
+        {
+            0x7f800001,
+            0x7f8ffff1,
+            0xff800001,
+        },
+        {
+            0xff8ffff1,
+            0xffffffff,
+        },
+    };
+
+
+    // Infinity values (Positive)
+    public static float s_ipf0 = 0x7f800000;
+    public float d_ipf0 = 0x7f800000;
+    public static float[] s_a_ipf = {
+        0x7f800000,
+        0x7f800000,
+    };
+    public float[] d_a_ipf = {
+        0x7f800000,
+        0x7f800000,
+    };
+    public static float[][] s_ma_ipf = {
+        {
+            0x7f800000,
+        },
+        {
+            0x7f800000,
+        },
+    };
+    public float[][] d_ma_ipf = {
+        {
+            0x7f800000,
+        },
+        {
+            0x7f800000,
+        },
+    };
+
+    // Infinity values (Negative)
+    public static float s_inf0 = 0xff800000;
+    public float d_inf0 = 0xff800000;
+    public static float[] s_a_inf = {
+        0x7f800000,
+        0xff800000,
+    };
+    public float[] d_a_inf = {
+        0x7f800000,
+        0xff800000,
+    };
+    public static float[][] s_ma_inf = {
+        {
+            0x7f800000,
+            0xff800000,
+        },
+        {
+            0x7f800000,
+            0xff800000,
+        },
+    };
+    public float[][] d_ma_inf = {
+        {
+            0x7f800000,
+            0xff800000,
+        },
+        {
+            0x7f800000,
+            0xff800000,
+        },
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForIntTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForIntTest.java
@@ -1,0 +1,74 @@
+class BoundaryValueTypeForIntTest
+{
+    // boundary value tests for Integers
+    public static int s_i0 = 1234;
+    public static int s_i1 = 32767;
+    public static int s_i2 = 32768;
+    public static int s_i3 = 2147483647;
+    public static int s_i4 = -1;
+    public static int s_i5 = -1234;
+    public static int s_i6 = -2147483648;
+    public static int s_i7 = -32768;
+    public static int s_i8 = 0;
+    public int d_i0 = 1234;
+    public int d_i1 = 32767;
+    public int d_i2 = 32768;
+    public int d_i3 = 2147483647;
+    public int d_i4 = -1;
+    public int d_i5 = -1234;
+    public int d_i6 = -2147483648;
+    public int d_i7 = -32768;
+    public int d_i8 = 0;
+    public static int[] s_a_i = {
+        1234,
+        32767,
+        32768,
+        2147483647,
+        -1,
+        -1234,
+        -2147483648,
+        -32768,
+        0,
+    };
+    public int[] d_a_i = {
+        1234,
+        32767,
+        32768,
+        2147483647,
+        -1,
+        -1234,
+        -2147483648,
+        -32768,
+        0,
+    };
+    public static int[][] s_ma_i = {
+        {
+            1234,
+            32767,
+            32768,
+            2147483647,
+        },
+        {
+            -1,
+            -1234,
+            -2147483648,
+            -32768,
+            0,
+        },
+    };
+    public int[][] d_ma_i = {
+        {
+            1234,
+            32767,
+            32768,
+            2147483647,
+        },
+        {
+            -1,
+            -1234,
+            -2147483648,
+            -32768,
+            0,
+        },
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForLongTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForLongTest.java
@@ -1,0 +1,86 @@
+class BoundaryValueTypeForLongTest
+{
+    // boundary value tests for Longs
+    public static long s_l0 = 1234L;
+    public static long s_l1 = 32767L;
+    public static long s_l2 = 32768L;
+    public static long s_l3 = 2147483647L;
+    public static long s_l4 = -1L;
+    public static long s_l5 = -1234L;
+    public static long s_l6 = -2147483648L;
+    public static long s_l7 = -32768L;
+    public static long s_l8 = -9223372036854775808L;
+    public static long s_l9 = 9223372036854775807L;
+    public static long s_l10 = 0L;
+    public long d_l0 = 1234L;
+    public long d_l1 = 32767L;
+    public long d_l2 = 32768L;
+    public long d_l3 = 2147483647L;
+    public long d_l4 = -1L;
+    public long d_l5 = -1234L;
+    public long d_l6 = -2147483648L;
+    public long d_l7 = -32768L;
+    public long d_l8 = -9223372036854775808L;
+    public long d_l9 = 9223372036854775807L;
+    public long d_l10 = 0L;
+    public static long[] s_a_l = {
+        1234L,
+        32767L,
+        32768L,
+        2147483647L,
+        -1L,
+        -1234L,
+        -2147483648L,
+        -32768L,
+        -9223372036854775808L,
+        9223372036854775807L,
+        0L,
+    };
+    public long[] d_a_l = {
+        1234L,
+        32767L,
+        32768L,
+        2147483647L,
+        -1L,
+        -1234L,
+        -2147483648L,
+        -32768L,
+        -9223372036854775808L,
+        9223372036854775807L,
+        0L,
+    };
+    public static long[][] s_ma_l = {
+        {
+            1234L,
+            32767L,
+            32768L,
+            2147483647L,
+            -1L,
+            -1234L,
+        },
+        {
+            -2147483648L,
+            -32768L,
+            -9223372036854775808L,
+            9223372036854775807L,
+            0L,
+        },
+    };
+    public long[][] d_ma_l = {
+        {
+            1234L,
+            32767L,
+            32768L,
+            2147483647L,
+            -1L,
+            -1234L,
+        },
+        {
+            -2147483648L,
+            -32768L,
+            -9223372036854775808L,
+            9223372036854775807L,
+            0L,
+        },
+    };
+}

--- a/tests/fixtures/java/BoundaryValueTypeForShortTest.java
+++ b/tests/fixtures/java/BoundaryValueTypeForShortTest.java
@@ -1,0 +1,56 @@
+class BoundaryValueTypeForShortTest
+{
+    // boundary value tests for Shorts
+    public static short s_s0 = 1234;
+    public static short s_s1 = 32767;
+    public static short s_s2 = -1;
+    public static short s_s3 = -1234;
+    public static short s_s4 = -32768;
+    public static short s_s5 = 0;
+    public short d_s0 = 1234;
+    public short d_s1 = 32767;
+    public short d_s2 = -1;
+    public short d_s3 = -1234;
+    public short d_s4 = -32768;
+    public short d_s5 = 0;
+    public static short[] s_a_s = {
+        1234,
+        32767,
+        -1,
+        -1234,
+        -32768,
+        0,
+    };
+    public short[] d_a_s = {
+            1234,
+            32767,
+            -1,
+            -1234,
+            -32768,
+            0,
+    };
+    public static short[][] s_ma_s = {
+        {
+            1234,
+            32767,
+            -1,
+        },
+        {
+            -1234,
+            -32768,
+            0,
+        },
+    };
+    public short[][] d_ma_s = {
+        {
+            1234,
+            32767,
+            -1,
+        },
+        {
+            -1234,
+            -32768,
+            0,
+        },
+    };
+}


### PR DESCRIPTION
Related: https://github.com/php-java/php-java/issues/188

#### Prefix meanings
(`<N>` is a number)
- `s_`: That is a `static` field.
- `d_`: That is a `dynamic` field.
- `_a_`: That is an `array` field.
- `_ma_`: That is a `multi dimension array` field.
- `i<N>`: That is an int type.
- `l<N>`: That is a long type.
- `s<N>`: That is a short type.
- `b<N>`: That is a boolean type.
- `by<N>`: That is a byte type.
- `c<N>`: That is a char type.
- `f<N>`: That is a float type.
- `d<N>`: That is a double type.