### PR TITLE
Fix println to be callable without parameters

### DIFF
--- a/src/Packages/java/io/PrintStream.php
+++ b/src/Packages/java/io/PrintStream.php
@@ -11,8 +11,22 @@ class PrintStream
 {
     private $sequence = '';
 
-    public function println($arg)
+    public function println(...$arguments)
     {
+        $length = count($arguments);
+        if ($length > 1) {
+            throw new \InvalidArgumentException(
+                "The argument array should have 0 or 1 element, but has {$length} elements."
+            );
+        }
+
+        if ($length === 0) {
+            echo "\n";
+            return;
+        }
+
+        $arg = $arguments[0];
+
         if ($arg instanceof Utf8Info) {
             echo $arg->getString() . "\n";
             return;

--- a/tests/Packages/JavaIoPrintStreamClassTest.php
+++ b/tests/Packages/JavaIoPrintStreamClassTest.php
@@ -23,6 +23,12 @@ class JavaIoPrintStreamClassTest extends Base
         return ob_get_clean();
     }
 
+    public function testPrintlnWithoutParams()
+    {
+        $result = $this->call(explode('::', __METHOD__)[1]);
+        $this->assertEquals("\n", $result);
+    }
+
     public function testPrintlnWithStringParams()
     {
         $result = $this->call(explode('::', __METHOD__)[1]);

--- a/tests/fixtures/java/JavaIoPrintStreamClassTest.java
+++ b/tests/fixtures/java/JavaIoPrintStreamClassTest.java
@@ -1,5 +1,10 @@
 class JavaIoPrintStreamClassTest
 {
+    public static void testPrintlnWithoutParams()
+    {
+	System.out.println();
+    }
+
     public static void testPrintlnWithStringParams()
     {
         String x = "Hello World";


### PR DESCRIPTION
Supports println(void).
