### PR TITLE
print/println return without exception when null string is given

### DIFF
--- a/src/Packages/java/io/PrintStream.php
+++ b/src/Packages/java/io/PrintStream.php
@@ -159,6 +159,7 @@ class PrintStream extends FilterOutputStream // implements Closeable, Appendable
 
         if ($typeName === \PHPJava\Packages\java\lang\String::class) {
             Output::write('null');
+            return;
         }
 
         throw new NullPointerException();

--- a/tests/Cases/Packages/JavaIoPrintStreamClassTest.php
+++ b/tests/Cases/Packages/JavaIoPrintStreamClassTest.php
@@ -16,15 +16,21 @@ class JavaIoPrintStreamClassTest extends Base
 
     private function call($method, ...$arguments)
     {
+        static::$initiatedJavaClasses['JavaIoPrintStreamClassTest']
+            ->getInvoker()
+            ->getStatic()
+            ->getMethods()
+            ->call(
+                $method,
+                ...$arguments
+            );
+        return Output::getHeapspace();
+    }
+
+    private function callWithExpectingException($method, ...$arguments)
+    {
         try {
-            static::$initiatedJavaClasses['JavaIoPrintStreamClassTest']
-                ->getInvoker()
-                ->getStatic()
-                ->getMethods()
-                ->call(
-                    $method,
-                    ...$arguments
-                );
+            return $this->call($method, ...$arguments);
         } catch (UncaughtException $e) {
             $this->expectedSpecialException = get_class($e->getPrevious());
         }
@@ -47,10 +53,6 @@ class JavaIoPrintStreamClassTest extends Base
     {
         $result = $this->call(explode('::', __METHOD__)[1]);
         $this->assertEquals("null\n", $result);
-        $this->assertSame(
-            NullPointerException::class,
-            $this->expectedSpecialException
-        );
     }
 
     public function testPrintlnWithCharParams()
@@ -67,7 +69,7 @@ class JavaIoPrintStreamClassTest extends Base
 
     public function testPrintlnWithNullCharArrayParams()
     {
-        $result = $this->call(explode('::', __METHOD__)[1]);
+        $result = $this->callWithExpectingException(explode('::', __METHOD__)[1]);
         $this->assertEquals("\n", $result);
         $this->assertSame(
             NullPointerException::class,
@@ -106,10 +108,6 @@ class JavaIoPrintStreamClassTest extends Base
     {
         $result = $this->call(explode('::', __METHOD__)[1]);
         $this->assertEquals('null', $result);
-        $this->assertSame(
-            NullPointerException::class,
-            $this->expectedSpecialException
-        );
     }
 
     public function testPrintWithCharParams()
@@ -126,7 +124,7 @@ class JavaIoPrintStreamClassTest extends Base
 
     public function testPrintWithNullCharArrayParams()
     {
-        $result = $this->call(explode('::', __METHOD__)[1]);
+        $result = $this->callWithExpectingException(explode('::', __METHOD__)[1]);
         $this->assertEquals('', $result);
         $this->assertSame(
             NullPointerException::class,


### PR DESCRIPTION
Easy fix: added return statement to the null string case.
And I suggest to separate `call` method in the test class, because it hides unexpected exceptions.