### PR TITLE
feat: Support Java classes v56 (Java 12) to v63 (Java 19)

### DIFF
--- a/src/Kernel/Resolvers/SDKVersionResolver.php
+++ b/src/Kernel/Resolvers/SDKVersionResolver.php
@@ -19,6 +19,14 @@ class SDKVersionResolver
         '53.0' => '9',
         '54.0' => '10',
         '55.0' => '11',
+        '56.0' => '12',
+        '57.0' => '13',
+        '58.0' => '14',
+        '59.0' => '15',
+        '60.0' => '16',
+        '61.0' => '17',
+        '62.0' => '18',
+        '63.0' => '19',
     ];
 
     public static function resolveByVersion(string $version): array


### PR DESCRIPTION
This adds support of Java classes version 56.0 to 63.0 inclusive.
Reference: https://docs.oracle.com/javase/specs/jvms/se19/html/jvms-4.html#jvms-4.1-200-B.2